### PR TITLE
Add metrics to the collector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "activesupport", "~> 5.2.2"
 gem "concurrent-ruby"
 gem "more_core_extensions"
 gem "optimist"
+gem "prometheus_exporter", "~> 0.4.5"
 gem "rake"
 gem "manageiq-loggers", "~> 0.1.1"
 

--- a/bin/ansible_tower-collector
+++ b/bin/ansible_tower-collector
@@ -7,6 +7,7 @@ STDOUT.sync = true
 
 require "bundler/setup"
 require "topological_inventory/ansible_tower/collector"
+require "topological_inventory/ansible_tower/collector/application_metrics"
 
 #
 # You can add local requires to /lib/require.dev.rb
@@ -39,6 +40,8 @@ def parse_args
     opt :user, "Username to AnsibleTower", :type => :string, :required => ENV["ENDPOINT_USER"].nil?, :default => ENV["ENDPOINT_USER"] || defaults[:user]
     opt :password, "Password to Ansible Tower", :type => :string, :required => ENV["ENDPOINT_PASSWORD"].nil?, :default => ENV["ENDPOINT_PASSWORD"] || defaults[:password]
     opt :ingress_api, "Hostname of the ingress-api route", :type => :string, :default => ENV["INGRESS_API"] || defaults[:ingress_api]
+    opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics",
+        :type => :integer, :default => (ENV["METRICS_PORT"] || 9394).to_i
   end
 
   opts
@@ -51,5 +54,10 @@ ingress_api_uri = URI(args[:ingress_api])
 TopologicalInventoryIngressApiClient.configure.scheme = ingress_api_uri.scheme || "http"
 TopologicalInventoryIngressApiClient.configure.host   = "#{ingress_api_uri.host}:#{ingress_api_uri.port}"
 
-collector = TopologicalInventory::AnsibleTower::Collector.new(args[:source], "#{args[:scheme]}://#{args[:host]}", args[:user], args[:password])
-collector.collect!
+begin
+  metrics = TopologicalInventory::AnsibleTower::Collector::ApplicationMetrics.new(args[:metrics_port])
+  collector = TopologicalInventory::AnsibleTower::Collector.new(args[:source], "#{args[:scheme]}://#{args[:host]}", args[:user], args[:password], metrics)
+  collector.collect!
+ensure
+  metrics.stop_server
+end

--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -11,13 +11,14 @@ module TopologicalInventory::AnsibleTower
     require "topological_inventory/ansible_tower/collector/service_catalog"
     include TopologicalInventory::AnsibleTower::Collector::ServiceCatalog
 
-    def initialize(source, tower_hostname, tower_user, tower_passwd)
+    def initialize(source, tower_hostname, tower_user, tower_passwd, metrics)
       super(source, :default_limit => 5)
 
       self.connection_manager = TopologicalInventory::AnsibleTower::Connection.new
       self.tower_hostname = tower_hostname
       self.tower_user = tower_user
       self.tower_passwd = tower_passwd
+      self.metrics = metrics
     end
 
     def collect!
@@ -28,7 +29,8 @@ module TopologicalInventory::AnsibleTower
 
     private
 
-    attr_accessor :connection_manager, :tower_hostname, :tower_user, :tower_passwd
+    attr_accessor :connection_manager, :tower_hostname, :tower_user, :tower_passwd,
+                  :metrics
 
     def endpoint_types
       %w[service_catalog]
@@ -86,8 +88,9 @@ module TopologicalInventory::AnsibleTower
       # connection.api.jobs.all
       # connection.api.workflow_jobs.all
     rescue => e
+      metrics.record_error
       logger.error("Error collecting :#{entity_type}, message => #{e.message}")
-      raise e
+      logger.error(e)
     end
   end
 end

--- a/lib/topological_inventory/ansible_tower/collector/application_metrics.rb
+++ b/lib/topological_inventory/ansible_tower/collector/application_metrics.rb
@@ -1,0 +1,45 @@
+require "prometheus_exporter"
+require "prometheus_exporter/server"
+require "prometheus_exporter/client"
+require 'prometheus_exporter/instrumentation'
+
+module TopologicalInventory
+  module AnsibleTower
+    class Collector
+      class ApplicationMetrics
+        def initialize(port = 9394)
+          return if port == 0
+
+          configure_server(port)
+          configure_metrics
+        end
+
+        def record_error
+          @errors_counter&.observe(1)
+        end
+
+        def stop_server
+          @server&.stop
+        end
+
+        private
+
+        def configure_server(port)
+          @server = PrometheusExporter::Server::WebServer.new(:port => port)
+          @server.start
+
+          PrometheusExporter::Client.default = PrometheusExporter::LocalClient.new(:collector => @server.collector)
+        end
+
+        def configure_metrics
+          PrometheusExporter::Instrumentation::Process.start
+
+          PrometheusExporter::Metric::Base.default_prefix = "topological_inventory_ansible_tower_collector_"
+
+          @errors_counter = PrometheusExporter::Metric::Counter.new("errors_total", "total number of collector errors")
+          @server.collector.register_metric(@errors_counter)
+        end
+      end
+    end
+  end
+end

--- a/spec/application_metrics_spec.rb
+++ b/spec/application_metrics_spec.rb
@@ -1,0 +1,38 @@
+require "topological_inventory/ansible_tower/collector/application_metrics"
+require "active_support/core_ext/string"
+require "net/http"
+
+RSpec.describe TopologicalInventory::AnsibleTower::Collector::ApplicationMetrics do
+  subject! { described_class.new(9394) }
+  after    { subject.stop_server }
+
+  context "Turned on" do
+    it "exposes metrics" do
+      subject.record_error
+      subject.record_error
+
+      metrics = get_metrics
+      expect(metrics["topological_inventory_ansible_tower_collector_errors_total"]).to eq("2")
+    end
+
+    def get_metrics
+      metrics = Net::HTTP.get(URI("http://localhost:9394/metrics")).split("\n").delete_if do |e|
+        e.blank? || e.start_with?("#")
+      end
+
+      metrics.each_with_object({}) do |m, hash|
+        k, v = m.split
+        hash[k] = v
+      end
+    end
+  end
+
+  context "Turned off" do
+    subject! { described_class.new(0) }
+
+    it "doesn't raise exception" do
+      expect { subject.record_error }.not_to raise_exception
+      expect { subject.stop_server }.not_to raise_exception
+    end
+  end
+end


### PR DESCRIPTION
This adds an in-process metrics server using the prometheus exporter
gem and records an error metric each time an exception is caught
in the collector loop.