### PR TITLE
MultiSource Collector using config yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ bundler.d/*
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
 
+# dev configs
+/config/*-dev.yml
 
 # rspec failure tracking
 .rspec_status

--- a/bin/ansible_tower-collector
+++ b/bin/ansible_tower-collector
@@ -7,6 +7,7 @@ STDOUT.sync = true
 
 require "bundler/setup"
 require "topological_inventory/ansible_tower/collector"
+require "topological_inventory/ansible_tower/collectors_pool"
 require "topological_inventory/ansible_tower/collector/application_metrics"
 
 #
@@ -17,33 +18,52 @@ require require_dev_path if File.exist?(require_dev_path)
 
 #
 # Input args
+# --config      (ENV["CONFIG"])          - Config file name (without .yml suffix) - file located in "config" dir.
 # --source      (ENV["SOURCE_UID"])      - core: Source.uid (manager for this collector)
 # --scheme      (ENV["ENDPOINT_SCHEME"]) - ansible tower scheme, https by default
 # --host        (ENV["ENDPOINT_HOST"])   - ansible tower url
 # --user        (ENV["AUTH_USERNAME"])   - credentials: username
 # --password    (ENV["AUTH_PASSWORD"])   - credentials: password
-# --ingress_api (ENV["INGRESS_API"])     - ingress api server, by default *localhost:9292*
+# --ingress-api (ENV["INGRESS_API"])     - ingress api server, by default *localhost:9292*
+# --metrics-port(ENV["METRICS_PORT"])    - Prometheus metrics port, default *9394*, disabled when *0*
 #
 def parse_args
-  defaults = {
-    :scheme      => 'https',
-    :ingress_api => 'http://localhost:9292'
-  }
-
   require 'optimist'
   Optimist.options do
-    opt :source, "Inventory Source UID", :type => :string, :required => ENV["SOURCE_UID"].nil?, :default => ENV["SOURCE_UID"]
-    opt :scheme, "Protocol scheme for connecting to the AnsibleTower REST API, default: https", :type => :string, :required => ENV["ENDPOINT_SCHEME"].nil?, :default => ENV["ENDPOINT_SCHEME"] || defaults[:scheme]
-    opt :host, "IP address or hostname of the Ansible Tower REST API", :type => :string, :required => ENV["ENDPOINT_HOST"].nil?, :default => ENV["ENDPOINT_HOST"]
-    opt :user, "Username to AnsibleTower", :type => :string, :required => ENV["AUTH_USERNAME"].nil?, :default => ENV["AUTH_USERNAME"]
-    opt :password, "Password to Ansible Tower", :type => :string, :required => ENV["AUTH_PASSWORD"].nil?, :default => ENV["AUTH_PASSWORD"]
-    opt :ingress_api, "Hostname of the ingress-api route", :type => :string, :default => ENV["INGRESS_API"] || defaults[:ingress_api]
+    opt :config, "Sources configuration YAML file",
+        :type => :string, :default => ENV["CONFIG"]
+    opt :source, "Inventory Source UID",
+        :type => :string, :default => ENV["SOURCE_UID"]
+    opt :scheme, "Protocol scheme for connecting to the AnsibleTower REST API, default: https",
+        :type => :string, :default => ENV["ENDPOINT_SCHEME"] || 'https'
+    opt :host, "IP address or hostname of the Ansible Tower REST API",
+        :type => :string, :default => ENV["ENDPOINT_HOST"]
+    opt :user, "Username to AnsibleTower",
+        :type => :string, :default => ENV["AUTH_USERNAME"]
+    opt :password, "Password to Ansible Tower",
+        :type => :string, :default => ENV["AUTH_PASSWORD"]
+    opt :ingress_api, "Hostname of the ingress-api route",
+        :type => :string, :default => ENV["INGRESS_API"] || "http://localhost:9292"
     opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics",
         :type => :integer, :default => (ENV["METRICS_PORT"] || 9394).to_i
   end
 end
 
+# Params for single-source mode and multi-source mode are mutually exclusive
+def check_mode(opts)
+  single_source_args = %i[source host user password]
+  if opts[:config].nil?
+    single_source_args.each do |arg|
+      Optimist::die arg, "can't be nil" if opts[arg].nil?
+    end
+  else
+    Optimist::die :config, "not applicable in single-source mode" if single_source_args.any? { |arg| opts[arg].present? }
+  end
+end
+
 args = parse_args
+
+check_mode(args)
 
 ingress_api_uri = URI(args[:ingress_api])
 
@@ -52,8 +72,14 @@ TopologicalInventoryIngressApiClient.configure.host   = "#{ingress_api_uri.host}
 
 begin
   metrics = TopologicalInventory::AnsibleTower::Collector::ApplicationMetrics.new(args[:metrics_port])
-  collector = TopologicalInventory::AnsibleTower::Collector.new(args[:source], "#{args[:scheme]}://#{args[:host]}", args[:user], args[:password], metrics)
-  collector.collect!
+  if args[:config].nil?
+    collector = TopologicalInventory::AnsibleTower::Collector.new(args[:source], "#{args[:scheme]}://#{args[:host]}", args[:user], args[:password], metrics)
+    collector.collect!
+  else
+    pool = TopologicalInventory::AnsibleTower::CollectorsPool.new(args[:config], metrics)
+    pool.run!
+  end
 ensure
+  pool&.stop!
   metrics.stop_server
 end

--- a/config/example.yml
+++ b/config/example.yml
@@ -1,0 +1,12 @@
+# You can use *-dev.yml for your development sources
+sources:
+  - source: 31b5338b-685d-4056-ba39-d00b4d7f19cc
+    scheme: https
+    host: host1
+    user: user1
+    password: password1
+  - source: a09b9785-0f71-4dcf-9f9d-de0f0478b09f
+    scheme: https
+    host: host2
+    user: user2
+    password: password2

--- a/lib/topological_inventory/ansible_tower/collectors_pool.rb
+++ b/lib/topological_inventory/ansible_tower/collectors_pool.rb
@@ -1,0 +1,21 @@
+require "topological_inventory-ingress_api-client/collectors_pool"
+require "topological_inventory/ansible_tower/collector"
+require "topological_inventory/ansible_tower/logging"
+
+module TopologicalInventory::AnsibleTower
+  class CollectorsPool < TopologicalInventoryIngressApiClient::CollectorsPool
+    include Logging
+
+    def initialize(config_name, metrics, poll_time: 10)
+      super
+    end
+
+    def path_to_config
+      File.expand_path("../../../config", File.dirname(__FILE__))
+    end
+
+    def new_collector(source)
+      TopologicalInventory::AnsibleTower::Collector.new(source.source, source.host, source.user, source.password, metrics)
+    end
+  end
+end

--- a/lib/topological_inventory/ansible_tower/parser/service_plan.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_plan.rb
@@ -2,7 +2,8 @@ module TopologicalInventory::AnsibleTower
   class Parser
     module ServicePlan
       def parse_service_plan(template, survey_spec_hash)
-        return if survey_spec_hash.blank?
+        # Each service_offering must have service_plan to make catalog able to order it
+        survey_spec_hash = {} if survey_spec_hash.nil?
 
         collections.service_plans.build(
           parse_base_item(template).merge(
@@ -47,8 +48,8 @@ module TopologicalInventory::AnsibleTower
         {
           :schemaType => 'default',
           :schema     => {
-            :title       => survey['name'],
-            :description => survey['description'],
+            :title       => survey['name'] || '',
+            :description => survey['description'] || '',
             :fields      => []
           }
         }


### PR DESCRIPTION
Multiple sources can be handled with yaml config's credentials

**Issue**: ManageIQ/topological_inventory-orchestrator#27

* [x] **depends on** ManageIQ/topological_inventory-ingress_api-client-ruby#42