### PR TITLE
dataType field to ServicePlan's create_json_schema

### DIFF
--- a/lib/topological_inventory/ansible_tower/parser/service_plan.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_plan.rb
@@ -77,8 +77,13 @@ module TopologicalInventory::AnsibleTower
 
       def add_integer_properties!(_survey_input, output)
         output[:type] = 'number'
+        output[:dataType] = 'integer'
       end
-      alias add_float_properties! add_integer_properties!
+
+      def add_float_properties!(_survey_input, output)
+        output[:type] = 'number'
+        output[:dataType] = 'number'
+      end
 
       def add_multiselect_properties!(survey_input, output)
         output[:initialValue] = survey_input['default'].split("\n")

--- a/lib/topological_inventory/ansible_tower/parser/service_plan.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_plan.rb
@@ -82,7 +82,7 @@ module TopologicalInventory::AnsibleTower
 
       def add_float_properties!(_survey_input, output)
         output[:type] = 'number'
-        output[:dataType] = 'number'
+        output[:dataType] = 'float'
       end
 
       def add_multiselect_properties!(survey_input, output)

--- a/spec/parser/service_plan_spec.rb
+++ b/spec/parser/service_plan_spec.rb
@@ -178,7 +178,8 @@ describe TopologicalInventory::AnsibleTower::Parser do
               {:type => "min-number-value", :value => 1},
               {:type => "max-number-value", :value => 100}
             ],
-            :type         => "number"
+            :type         => "number",
+            :dataType     => "integer"
           },
           {
             :component    => "text-field",
@@ -190,7 +191,8 @@ describe TopologicalInventory::AnsibleTower::Parser do
               {:type => "min-number-value", :value => -1},
               {:type => "max-number-value", :value => 100.54}
             ],
-            :type         => "number"
+            :type         => "number",
+            :dataType     => "number"
           }
         ]
       }

--- a/spec/parser/service_plan_spec.rb
+++ b/spec/parser/service_plan_spec.rb
@@ -192,7 +192,7 @@ describe TopologicalInventory::AnsibleTower::Parser do
               {:type => "max-number-value", :value => 100.54}
             ],
             :type         => "number",
-            :dataType     => "number"
+            :dataType     => "float"
           }
         ]
       }


### PR DESCRIPTION
Collected JobTemplate's Surveys are saved as `ServicePlan.create_json_schema`.

Adding  field `dataType` for integer(value 'integer') and float(value 'number') values.
Other types are strings and doesn't have `dataType` filled.