### PR TITLE
Workflow job templates ordering

### DIFF
--- a/lib/topological_inventory/ansible_tower/operations/core/ansible_tower_client.rb
+++ b/lib/topological_inventory/ansible_tower/operations/core/ansible_tower_client.rb
@@ -49,8 +49,12 @@ module TopologicalInventory
           #       "providerControlParameters":{"namespace":"default"},
           #       ...
           #     }"
-          def order_service_plan(job_template_id, order_params)
-            job_template = ansible_tower.api.job_templates.find(job_template_id)
+          def order_service_plan(job_type, job_template_id, order_params)
+            job_template = if job_type == 'workflow_job_template'
+                             ansible_tower.api.workflow_job_templates.find(job_template_id)
+                           else
+                             ansible_tower.api.job_templates.find(job_template_id)
+                           end
 
             job = job_template.launch(job_values(order_params))
 
@@ -66,7 +70,11 @@ module TopologicalInventory
             last_status = nil
             timeout_count = POLL_TIMEOUT / SLEEP_POLL
             loop do
-              job = ansible_tower.api.jobs.find(job.id)
+              job = if job.type == 'workflow_job'
+                      ansible_tower.api.workflow_jobs.find(job.id)
+                    else
+                      ansible_tower.api.jobs.find(job.id)
+                    end
 
               if last_status != job.status
                 last_status = job.status

--- a/lib/topological_inventory/ansible_tower/operations/processor.rb
+++ b/lib/topological_inventory/ansible_tower/operations/processor.rb
@@ -47,8 +47,10 @@ module TopologicalInventory
 
           client = ansible_tower_client(source_id, task_id, identity)
 
+          job_type = parse_svc_offering_type(service_offering)
+
           logger.info("Ordering #{service_offering.name} #{service_plan.name}...")
-          job = client.order_service_plan(service_offering.source_ref, order_params)
+          job = client.order_service_plan(job_type, service_offering.source_ref, order_params)
           logger.info("Ordering #{service_offering.name} #{service_plan.name}...Complete")
 
           poll_order_complete_thread(task_id, source_id, job)
@@ -127,6 +129,15 @@ module TopologicalInventory
 
         def ansible_tower_client(source_id, task_id, identity)
           Core::AnsibleTowerClient.new(source_id, task_id, identity)
+        end
+
+        # Type defined by collector here:
+        # lib/topological_inventory/ansible_tower/parser/service_offering.rb:12
+        def parse_svc_offering_type(service_offering)
+          job_type = service_offering.extra[:type] if service_offering.extra.present?
+
+          raise "Missing service_offering's type: #{service_offering.inspect}" if job_type.blank?
+          job_type
         end
       end
     end


### PR DESCRIPTION
Job templates of Workflow job templates can be ordered.
Distinguished by ServiceOffering.extra[:type].

Then when waiting for job finished, (workflow) job is reloaded - api call distinguished by job.type