### PR TITLE
Operations: Task's context sent as hash

### DIFF
--- a/lib/topological_inventory/ansible_tower/operations/core/topology_api_client.rb
+++ b/lib/topological_inventory/ansible_tower/operations/core/topology_api_client.rb
@@ -13,7 +13,7 @@ module TopologicalInventory
           end
 
           def update_task(task_id, state:, status:, context:)
-            task = TopologicalInventoryApiClient::Task.new("state" => state, "status" => status, "context" => context.to_json)
+            task = TopologicalInventoryApiClient::Task.new("state" => state, "status" => status, "context" => context)
             topology_api_client.update_task(task_id, task)
           end
 


### PR DESCRIPTION
When updating Task through Topological API, `context` has to be sent as hash, not as json's string.

**depends on** https://github.com/ManageIQ/topological_inventory-api-client-ruby/pull/15
**depends on** https://github.com/ManageIQ/topological_inventory-api/pull/229