### PR TITLE
ServiceInstance external_url targets to Tower UI

### DIFF
--- a/lib/topological_inventory/ansible_tower/parser/service_instance.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_instance.rb
@@ -4,8 +4,8 @@ module TopologicalInventory::AnsibleTower
       def parse_service_instance(job_hash)
         job = job_hash[:job]
 
-        # Changing API url to UI url
-        external_url = URI.join(self.tower_host, job.url.to_s.gsub(/\A\/api\/v\d+/,"/#"))
+        # Set to tower UI url
+        external_url = URI.join(self.tower_host, "/#/jobs/playbook/#{job.id}")
 
         collections.service_instances.build(
           parse_base_item(job).merge(

--- a/lib/topological_inventory/ansible_tower/parser/service_instance.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_instance.rb
@@ -5,7 +5,8 @@ module TopologicalInventory::AnsibleTower
         job = job_hash[:job]
 
         # Set to tower UI url
-        external_url = URI.join(self.tower_host, "/#/jobs/playbook/#{job.id}")
+        path = job.type == 'workflow_job' ? 'workflows' : 'jobs/playbook'
+        external_url = File.join(self.tower_host, "/#/#{path}", job.id.to_s)
 
         collections.service_instances.build(
           parse_base_item(job).merge(
@@ -13,7 +14,7 @@ module TopologicalInventory::AnsibleTower
             :service_offering => lazy_find(:service_offerings, :source_ref => job.unified_job_template_id.to_s),
             # it creates skeletal service_plans because not all jobs have corresponding survey
             :service_plan     => lazy_find(:service_plans, :source_ref => job.unified_job_template_id.to_s),
-            :external_url     => external_url.to_s
+            :external_url     => external_url
           )
         )
       end

--- a/lib/topological_inventory/ansible_tower/parser/service_instance.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_instance.rb
@@ -4,7 +4,8 @@ module TopologicalInventory::AnsibleTower
       def parse_service_instance(job_hash)
         job = job_hash[:job]
 
-        external_url = URI.join(self.tower_host, job.url)
+        # Changing API url to UI url
+        external_url = URI.join(self.tower_host, job.url.to_s.gsub(/\A\/api\/v\d+/,"/#"))
 
         collections.service_instances.build(
           parse_base_item(job).merge(


### PR DESCRIPTION
ServiceInstance external_url targets to Tower UI instead of Tower API.

Before: https://18.222.137.244/api/v1/jobs/197/
After: https://18.222.137.244/#/jobs/playbook/197