### PR TITLE
Changed dockerfile's workdir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN yum -y install --setopt=tsflags=nodocs \
                    && \
     yum clean all
 
-ENV WORKDIR /opt/ansible_tower-collector/
+ENV WORKDIR /opt/ansible-tower-collector/
 WORKDIR $WORKDIR
 
 COPY Gemfile $WORKDIR


### PR DESCRIPTION
Workdir has to be compatible with SourceType.name to be able to mount config maps and secrets

**dependent** https://github.com/ManageIQ/topological_inventory-orchestrator/pull/31