### PR TITLE
Operations: Ordering by service_offering

### DIFF
--- a/lib/topological_inventory/ansible_tower/operations/core/ansible_tower_client.rb
+++ b/lib/topological_inventory/ansible_tower/operations/core/ansible_tower_client.rb
@@ -49,7 +49,7 @@ module TopologicalInventory
           #       "providerControlParameters":{"namespace":"default"},
           #       ...
           #     }"
-          def order_service_plan(job_type, job_template_id, order_params)
+          def order_service(job_type, job_template_id, order_params)
             job_template = if job_type == 'workflow_job_template'
                              ansible_tower.api.workflow_job_templates.find(job_template_id)
                            else

--- a/lib/topological_inventory/ansible_tower/operations/processor.rb
+++ b/lib/topological_inventory/ansible_tower/operations/processor.rb
@@ -55,7 +55,7 @@ module TopologicalInventory
           job_type = parse_svc_offering_type(service_offering)
 
           logger.info("Ordering #{service_offering.name}...")
-          job = client.order_service_plan(job_type, service_offering.source_ref, order_params)
+          job = client.order_service(job_type, service_offering.source_ref, order_params)
           logger.info("Ordering #{service_offering.name}...Complete")
 
           poll_order_complete_thread(task_id, source_id, job)

--- a/lib/topological_inventory/ansible_tower/operations/processor.rb
+++ b/lib/topological_inventory/ansible_tower/operations/processor.rb
@@ -39,19 +39,24 @@ module TopologicalInventory
         attr_accessor :identity, :model, :method, :params
 
         def order_service(params)
-          task_id, service_plan_id, order_params = params.values_at("task_id", "service_plan_id", "order_params")
+          task_id, service_offering_id, service_plan_id, order_params = params.values_at("task_id", "service_offering_id", "service_plan_id", "order_params")
 
-          service_plan     = topology_api_client.show_service_plan(service_plan_id)
-          service_offering = topology_api_client.show_service_offering(service_plan.service_offering_id)
-          source_id        = service_plan.source_id
+          # @deprecated, ordering by service plan will be removed
+          if service_offering_id.nil? && service_plan_id.present?
+            service_plan     = topology_api_client.show_service_plan(service_plan_id)
+            service_offering_id = service_plan.service_offering_id
+          end
+          service_offering = topology_api_client.show_service_offering(service_offering_id)
+
+          source_id        = service_offering.source_id
 
           client = ansible_tower_client(source_id, task_id, identity)
 
           job_type = parse_svc_offering_type(service_offering)
 
-          logger.info("Ordering #{service_offering.name} #{service_plan.name}...")
+          logger.info("Ordering #{service_offering.name}...")
           job = client.order_service_plan(job_type, service_offering.source_ref, order_params)
-          logger.info("Ordering #{service_offering.name} #{service_plan.name}...Complete")
+          logger.info("Ordering #{service_offering.name}...Complete")
 
           poll_order_complete_thread(task_id, source_id, job)
         rescue StandardError => err

--- a/spec/operations/ansible_tower_client_spec.rb
+++ b/spec/operations/ansible_tower_client_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::Core::AnsibleTowe
 
       expect(@api).to receive(:job_templates).once
 
-      svc_instance = ansible_tower_client.order_service_plan("job_template", 1, order_params)
+      svc_instance = ansible_tower_client.order_service("job_template", 1, order_params)
       expect(svc_instance).to eq(job)
     end
 
@@ -49,7 +49,7 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::Core::AnsibleTowe
 
       expect(@api).to receive(:workflow_job_templates).once
 
-      svc_instance = ansible_tower_client.order_service_plan("workflow_job_template", 1, order_params)
+      svc_instance = ansible_tower_client.order_service("workflow_job_template", 1, order_params)
       expect(svc_instance).to eq(job)
     end
   end

--- a/spec/operations/processor_spec.rb
+++ b/spec/operations/processor_spec.rb
@@ -1,27 +1,14 @@
 require "topological_inventory/ansible_tower/operations/processor"
 
 RSpec.describe TopologicalInventory::AnsibleTower::Operations::Processor do
-  let(:payload) do
-    {
-      'request_context' => {"x-rh-identity" => 'abcd'},
-      'params'          => {
-        'order_params'    => {
-          'service_plan_id'             => 1,
-          'service_parameters'          => { :name   => "Job 1",
-                                             :param1 => "Test Topology",
-                                             :param2 => 50 },
-          'provider_control_parameters' => {}
-        },
-        'service_plan_id' => 1,
-        'task_id'         => 1 # in tp-inv api (Task)
-      }
-    }
-  end
   let(:topology_api_client) { double }
   let(:source_id) { 1 }
   let(:source_ref) { 1000 }
   let(:service_plan) { double("TopologicalInventoryApiClient::ServicePlan") }
   let(:service_offering) { double("TopologicalInventoryApiClient::ServiceOffering") }
+
+  # Overriden in contexts
+  let(:payload) { {} }
 
   before do
     @processor = described_class.new(nil, nil, payload)
@@ -29,14 +16,14 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::Processor do
 
     allow(service_plan).to receive(:service_offering_id).and_return(1)
     allow(service_plan).to receive(:name).and_return(double)
-    allow(service_plan).to receive(:source_id).and_return(source_id)
 
     allow(service_offering).to receive(:name).and_return(double)
     allow(service_offering).to receive(:source_ref).and_return(source_ref)
     allow(service_offering).to receive(:extra).and_return({:type => 'job_template'})
+    allow(service_offering).to receive(:source_id).and_return(source_id)
 
     @ansible_tower_client = double
-    allow(@ansible_tower_client).to receive(:order_service_plan)
+    allow(@ansible_tower_client).to receive(:order_service)
 
     allow(@processor).to receive(:ansible_tower_client).and_return(@ansible_tower_client)
     allow(@processor).to receive(:topology_api_client).and_return(topology_api_client)
@@ -45,35 +32,82 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::Processor do
     allow(topology_api_client).to receive(:show_service_offering).and_return(service_offering)
   end
 
-  describe "#order_service" do
-    it "orders job" do
-      allow(@processor).to receive(:poll_order_complete_thread).and_return(double)
-
-      expect(@ansible_tower_client).to receive(:order_service_plan).with("job_template", source_ref, payload['params']['order_params'])
-      @processor.send(:order_service, payload['params'])
+  context "Order by ServicePlan" do
+    let(:payload) do
+      {
+        'request_context' => {"x-rh-identity" => 'abcd'},
+        'params'          => {
+          'order_params'    => {
+            'service_plan_id'             => 1,
+            'service_parameters'          => { :name   => "Job 1",
+                                               :param1 => "Test Topology",
+                                               :param2 => 50 },
+            'provider_control_parameters' => {}
+          },
+          'service_plan_id' => 1,
+          'task_id'         => 1 # in tp-inv api (Task)
+        }
+      }
     end
 
-    it "updates task on error" do
-      err_message = "Sample error"
+    describe "#order_service" do
+      it "orders job" do
+        allow(@processor).to receive(:poll_order_complete_thread).and_return(double)
 
-      allow(@processor).to receive(:poll_order_complete_thread).and_return(double)
-      allow(@processor).to receive(:update_task).and_return(double)
-      allow(@ansible_tower_client).to receive(:order_service_plan).and_raise(err_message)
+        expect(@ansible_tower_client).to receive(:order_service).with("job_template", source_ref, payload['params']['order_params'])
+        @processor.send(:order_service, payload['params'])
+      end
 
-      expect(@processor).to receive(:update_task).with(payload['params']['task_id'], :state => "completed", :status => "error", :context => { :error => err_message })
+      it "updates task on error" do
+        err_message = "Sample error"
 
-      @processor.send(:order_service, payload['params'])
+        allow(@processor).to receive(:poll_order_complete_thread).and_return(double)
+        allow(@processor).to receive(:update_task).and_return(double)
+        allow(@ansible_tower_client).to receive(:order_service).and_raise(err_message)
+
+        expect(@processor).to receive(:update_task).with(payload['params']['task_id'], :state => "completed", :status => "error", :context => { :error => err_message })
+
+        @processor.send(:order_service, payload['params'])
+      end
+
+      it "raises error when service_offering doesn't have type" do
+        allow(@processor).to receive(:poll_order_complete_thread).and_return(double)
+        allow(@processor).to receive(:update_task).and_return(double)
+
+        allow(service_offering).to receive(:extra).and_return({})
+
+        expect(@processor).to receive(:parse_svc_offering_type).and_raise("Missing service_offering's type: #{service_offering.inspect}")
+
+        @processor.send(:order_service, payload['params'])
+      end
+    end
+  end
+
+  context "Order by ServiceOffering" do
+    let(:payload) do
+      {
+        'request_context' => {"x-rh-identity" => 'abcd'},
+        'params'          => {
+          'order_params'    => {
+            'service_offering_id'             => 1,
+            'service_parameters'          => { :name   => "Job 1",
+                                               :param1 => "Test Topology",
+                                               :param2 => 50 },
+            'provider_control_parameters' => {}
+          },
+          'service_offering_id' => 1,
+          'task_id'         => 1 # in tp-inv api (Task)
+        }
+      }
     end
 
-    it "raises error when service_offering doesn't have type" do
-      allow(@processor).to receive(:poll_order_complete_thread).and_return(double)
-      allow(@processor).to receive(:update_task).and_return(double)
+    describe "#order_service" do
+      it "orders job" do
+        allow(@processor).to receive(:poll_order_complete_thread).and_return(double)
 
-      allow(service_offering).to receive(:extra).and_return({})
-
-      expect(@processor).to receive(:parse_svc_offering_type).and_raise("Missing service_offering's type: #{service_offering.inspect}")
-
-      @processor.send(:order_service, payload['params'])
+        expect(@ansible_tower_client).to receive(:order_service).with("job_template", source_ref, payload['params']['order_params'])
+        @processor.send(:order_service, payload['params'])
+      end
     end
   end
 end


### PR DESCRIPTION
ServicePlan.id not needed, but kept for backward compatibility

**dependent**: https://github.com/ManageIQ/topological_inventory-api/pull/235