### PR TITLE
Multithreaded collector

### DIFF
--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -23,11 +23,12 @@ module TopologicalInventory::AnsibleTower
     end
 
     def collect!
-      loop do
-        entity_types.each do |entity_type|
-          collector_thread(connection_for_entity_type(entity_type), entity_type)
-        end
+      until finished?
+        ensure_collector_threads
 
+        collector_threads.each_value do |thread|
+          thread.join
+        end
         sleep(sleep_poll)
       end
     end


### PR DESCRIPTION
Collector was collecting entity types sequentially (it was intended only for simpler development). 
Switching to multi-threaded