### PR TITLE
Validation of collector input args

### DIFF
--- a/bin/ansible_tower-collector
+++ b/bin/ansible_tower-collector
@@ -81,5 +81,5 @@ begin
   end
 ensure
   pool&.stop!
-  metrics.stop_server
+  metrics&.stop_server
 end

--- a/lib/topological_inventory/ansible_tower/collectors_pool.rb
+++ b/lib/topological_inventory/ansible_tower/collectors_pool.rb
@@ -18,6 +18,16 @@ module TopologicalInventory::AnsibleTower
       File.expand_path("../../../secret", File.dirname(__FILE__))
     end
 
+    def source_valid?(source, secret)
+      missing_data = [source.source,
+                      source.host,
+                      secret["username"],
+                      secret["password"]].select do |data|
+        data.to_s.strip.blank?
+      end
+      missing_data.empty?
+    end
+
     def new_collector(source, secret)
       TopologicalInventory::AnsibleTower::Collector.new(source.source, source.host, secret["username"], secret["password"], metrics)
     end

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe TopologicalInventory::AnsibleTower::Collector do
+  let(:source_uid) { '7b901ca3-5414-4476-8d48-a722c1493de0' }
+  let(:logger) { double('Logger').as_null_object }
+  let(:client) { double('Ingress API Client')}
+
+  subject do
+    described_class.new(source_uid,
+                        'tower.example.com',
+                        'user',
+                        'passwd',
+                        nil)
+
+  end
+
+  before do
+    allow(subject).to receive(:logger).and_return(logger)
+    allow(subject).to receive(:ingress_api_client).and_return(client)
+  end
+end

--- a/spec/collectors_pool_spec.rb
+++ b/spec/collectors_pool_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe TopologicalInventory::AnsibleTower::CollectorsPool do
+  let(:source) { double("Source") }
+
+  subject { described_class.new(nil, nil) }
+
+  describe ".source_valid?" do
+    it "returns false if any of source, host, username, password are blank" do
+      (-1..3).each do |nil_index|
+        data = (0..3).collect { |j| nil_index == j ? nil : 'some_data' }
+        allow(source).to receive_messages(:source => data[0],
+                                          :host   => data[1])
+        secret = { "username" => data[2], "password" => data[3] }
+
+        expect(subject.source_valid?(source, secret)).to eq(nil_index == -1)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "topological_inventory/ansible_tower/collector"
+require "topological_inventory/ansible_tower/collectors_pool"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Input arguments of source in multisource mode are not tested in `bin script`. They should be tested before creating Thread with collector

- [x] **depends on** https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby/pull/51