### PR TITLE
Moving collector's common from ingress-api-client-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake"
 gem "sources-api-client",                       :git => "https://github.com/ManageIQ/sources-api-client-ruby", :branch => "master"
 gem 'topological_inventory-api-client',         :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
-
+gem "topological_inventory-providers-common",   :git => "https://github.com/slemrmartin/topological_inventory-providers-common", :branch => "master"
 group :development, :test do
   gem "rspec"
   gem "simplecov"

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "rake"
 gem "sources-api-client",                       :git => "https://github.com/ManageIQ/sources-api-client-ruby", :branch => "master"
 gem 'topological_inventory-api-client',         :git => "https://github.com/ManageIQ/topological_inventory-api-client-ruby", :branch => "master"
 gem "topological_inventory-ingress_api-client", :git => "https://github.com/ManageIQ/topological_inventory-ingress_api-client-ruby", :branch => "master"
-gem "topological_inventory-providers-common",   :git => "https://github.com/slemrmartin/topological_inventory-providers-common", :branch => "master"
+gem "topological_inventory-providers-common",   :git => "https://github.com/ManageIQ/topological_inventory-providers-common", :branch => "master"
 group :development, :test do
   gem "rspec"
   gem "simplecov"

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 gem "activesupport", "~> 5.2.2"
 gem "ansible_tower_client", "~> 0.19.0"
 gem "concurrent-ruby"
-gem "manageiq-loggers", "~> 0.1.1"
 gem "manageiq-messaging", "~> 0.1.2"
 gem "more_core_extensions"
 gem "optimist"

--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -1,11 +1,11 @@
 require "topological_inventory/ansible_tower/logging"
-require "topological_inventory-ingress_api-client/collector"
+require "topological_inventory/providers/common/collector"
 require "topological_inventory/ansible_tower/connection"
 require "topological_inventory/ansible_tower/parser"
 require "topological_inventory/ansible_tower/iterator"
 
 module TopologicalInventory::AnsibleTower
-  class Collector < TopologicalInventoryIngressApiClient::Collector
+  class Collector < TopologicalInventory::Providers::Common::Collector
     include Logging
 
     require "topological_inventory/ansible_tower/collector/service_catalog"

--- a/lib/topological_inventory/ansible_tower/collectors_pool.rb
+++ b/lib/topological_inventory/ansible_tower/collectors_pool.rb
@@ -1,9 +1,9 @@
-require "topological_inventory-ingress_api-client/collectors_pool"
+require "topological_inventory/providers/common/collectors_pool"
 require "topological_inventory/ansible_tower/collector"
 require "topological_inventory/ansible_tower/logging"
 
 module TopologicalInventory::AnsibleTower
-  class CollectorsPool < TopologicalInventoryIngressApiClient::CollectorsPool
+  class CollectorsPool < TopologicalInventory::Providers::Common::CollectorsPool
     include Logging
 
     def initialize(config_name, metrics, poll_time: 10)

--- a/lib/topological_inventory/ansible_tower/parser.rb
+++ b/lib/topological_inventory/ansible_tower/parser.rb
@@ -1,5 +1,5 @@
 module TopologicalInventory::AnsibleTower
-  class Parser < TopologicalInventoryIngressApiClient::Collector::Parser
+  class Parser < TopologicalInventory::Providers::Common::Collector::Parser
     require "topological_inventory/ansible_tower/parser/service_instance"
     require "topological_inventory/ansible_tower/parser/service_plan"
     require "topological_inventory/ansible_tower/parser/service_offering"


### PR DESCRIPTION
to providers-common gem, because ingress-api-client is built from generator

- [x] **depends on** https://github.com/slemrmartin/topological_inventory-providers-common/pull/1