### PR TITLE
Fixing Tower URL parsing in ServiceInstance

### DIFF
--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -54,7 +54,7 @@ module TopologicalInventory::AnsibleTower
     def collector_thread(connection, entity_type)
       refresh_state_uuid = SecureRandom.uuid
       logger.info("[START] Collecting #{entity_type} with :refresh_state_uuid => '#{refresh_state_uuid}'")
-      parser = TopologicalInventory::AnsibleTower::Parser.new(tower_host: tower_hostname)
+      parser = TopologicalInventory::AnsibleTower::Parser.new(tower_url: tower_hostname)
 
       total_parts = 0
       sweep_scope = Set.new
@@ -71,7 +71,7 @@ module TopologicalInventory::AnsibleTower
           save_inventory(parser.collections.values, inventory_name, schema_name, refresh_state_uuid, refresh_state_part_uuid)
           sweep_scope.merge(parser.collections.values.map(&:name))
           # re-init
-          parser = TopologicalInventory::AnsibleTower::Parser.new(tower_host: tower_hostname)
+          parser = TopologicalInventory::AnsibleTower::Parser.new(tower_url: tower_hostname)
           cnt = 0
         end
       end

--- a/lib/topological_inventory/ansible_tower/collectors_pool.rb
+++ b/lib/topological_inventory/ansible_tower/collectors_pool.rb
@@ -29,7 +29,10 @@ module TopologicalInventory::AnsibleTower
     end
 
     def new_collector(source, secret)
-      TopologicalInventory::AnsibleTower::Collector.new(source.source, source.host, secret["username"], secret["password"], metrics)
+      url = URI::Generic.build(:scheme => source.scheme.to_s.strip.presence || 'https',
+                               :host   => source.host.to_s.strip,
+                               :port   => source.port.to_s.strip)
+      TopologicalInventory::AnsibleTower::Collector.new(source.source, url.to_s, secret["username"], secret["password"], metrics)
     end
   end
 end

--- a/lib/topological_inventory/ansible_tower/parser.rb
+++ b/lib/topological_inventory/ansible_tower/parser.rb
@@ -8,12 +8,13 @@ module TopologicalInventory::AnsibleTower
     include TopologicalInventory::AnsibleTower::Parser::ServicePlan
     include TopologicalInventory::AnsibleTower::Parser::ServiceOffering
 
-    def initialize(tower_host:)
+    def initialize(tower_url:)
       super()
-
-      uri = URI(tower_host)
-      uri.scheme ||= "https"
-      self.tower_host = uri.to_s
+      self.tower_url = if tower_url.to_s.index('http').nil?
+                         File.join('https://', tower_url)
+                       else
+                         tower_url
+                       end
     end
 
     def parse_base_item(entity)
@@ -25,6 +26,6 @@ module TopologicalInventory::AnsibleTower
 
     protected
 
-    attr_accessor :tower_host
+    attr_accessor :tower_url
   end
 end

--- a/lib/topological_inventory/ansible_tower/parser/service_instance.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_instance.rb
@@ -6,7 +6,7 @@ module TopologicalInventory::AnsibleTower
 
         # Set to tower UI url
         path = job.type == 'workflow_job' ? 'workflows' : 'jobs/playbook'
-        external_url = File.join(self.tower_host, "/#/#{path}", job.id.to_s)
+        external_url = File.join(self.tower_url, "/#/#{path}", job.id.to_s)
 
         collections.service_instances.build(
           parse_base_item(job).merge(

--- a/spec/parser/service_plan_spec.rb
+++ b/spec/parser/service_plan_spec.rb
@@ -1,5 +1,5 @@
 describe TopologicalInventory::AnsibleTower::Parser do
-  let(:parser) { described_class.new(:tower_host => 'example.com') }
+  let(:parser) { described_class.new(:tower_url => 'example.com') }
   let(:survey) do
     {"description" => "",
      "name"        => "",


### PR DESCRIPTION
Main problem is, when creating service instance's url, it uses `url = URI("10.0.0.1")` which behaves unexpectedly, the value is in `url.path` instead of `url.host` and then `url.to_s` is wrong. 

Second problem is, that Collectors pool should add scheme from configmap