### PR TITLE
No need to create a blank service_plan anymore

### DIFF
--- a/lib/topological_inventory/ansible_tower/parser/service_offering.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_offering.rb
@@ -12,7 +12,7 @@ module TopologicalInventory::AnsibleTower
             :extra       => { :type => template_hash[:template_type] }
           )
         )
-        parse_service_plan(template, template_hash[:survey_spec])
+        parse_service_plan(template, template_hash[:survey_spec]) if template_hash[:survey_spec].present?
         service_offering
       end
     end

--- a/lib/topological_inventory/ansible_tower/parser/service_plan.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_plan.rb
@@ -2,8 +2,7 @@ module TopologicalInventory::AnsibleTower
   class Parser
     module ServicePlan
       def parse_service_plan(template, survey_spec_hash)
-        # Each service_offering must have service_plan to make catalog able to order it
-        survey_spec_hash = {} if survey_spec_hash.nil?
+        return if survey_spec_hash.nil?
 
         collections.service_plans.build(
           parse_base_item(template).merge(


### PR DESCRIPTION
Now that we support order on the service_offering we don't need to
create a blank service_plan any longer.