### PR TITLE
If we fail to find service_instance fail the task

### DIFF
--- a/lib/topological_inventory/ansible_tower/operations/core/topology_api_client.rb
+++ b/lib/topological_inventory/ansible_tower/operations/core/topology_api_client.rb
@@ -16,11 +16,6 @@ module TopologicalInventory
             task = TopologicalInventoryApiClient::Task.new("state" => state, "status" => status, "context" => context)
             topology_api_client.update_task(task_id, task)
           end
-
-          def svc_instance_url(service_instance)
-            return if service_instance.nil?
-            topology_api_client.api_client.build_request(:GET, "/service_instances/#{service_instance.id}").url
-          end
         end
       end
     end

--- a/lib/topological_inventory/ansible_tower/operations/core/topology_api_client.rb
+++ b/lib/topological_inventory/ansible_tower/operations/core/topology_api_client.rb
@@ -18,8 +18,8 @@ module TopologicalInventory
           end
 
           def svc_instance_url(service_instance)
-            rest_api_path = '/service_instances/{id}'.sub('{' + 'id' + '}', service_instance&.id.to_s)
-            topology_api_client.api_client.build_request(:GET, rest_api_path).url
+            return if service_instance.nil?
+            topology_api_client.api_client.build_request(:GET, "/service_instances/#{service_instance.id}").url
           end
         end
       end

--- a/lib/topological_inventory/ansible_tower/operations/processor.rb
+++ b/lib/topological_inventory/ansible_tower/operations/processor.rb
@@ -98,6 +98,7 @@ module TopologicalInventory
               # If we failed to find the service_instance in the topological-inventory-api
               # within 30 minutes then something went wrong.
               task_status = "error"
+              context[:error] = "Failed to find ServiceInstance by source_id [#{source_id}] source_ref [#{job.id}]"
             end
           end
 

--- a/lib/topological_inventory/ansible_tower/operations/processor.rb
+++ b/lib/topological_inventory/ansible_tower/operations/processor.rb
@@ -93,7 +93,7 @@ module TopologicalInventory
             svc_instance = wait_for_service_instance(source_id, job.id)
             if svc_instance.present?
               context[:service_instance][:id] = svc_instance.id
-              context[:service_instance][:url] = svc_instance_url(svc_instance)
+              context[:service_instance][:url] = svc_instance.external_url
             else
               # If we failed to find the service_instance in the topological-inventory-api
               # within 30 minutes then something went wrong.


### PR DESCRIPTION
The task should not be state: "completed", status: "ok" if we failed to
find the service_instance in the topology API after 30 minutes.