### PR TITLE
Log to cloud-watch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,9 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 
 gem "activesupport", "~> 5.2.2"
 gem "ansible_tower_client", "~> 0.19.0"
+gem "cloudwatchlogger",   "~> 0.2"
 gem "concurrent-ruby"
+gem "manageiq-loggers",   "~> 0.3.0"
 gem "manageiq-messaging", "~> 0.1.2"
 gem "more_core_extensions"
 gem "optimist"

--- a/lib/topological_inventory/ansible_tower/logging.rb
+++ b/lib/topological_inventory/ansible_tower/logging.rb
@@ -7,7 +7,7 @@ module TopologicalInventory
     end
 
     def self.logger
-      @logger ||= ManageIQ::Loggers::Container.new
+      @logger ||= ManageIQ::Loggers::CloudWatch.new
       @logger
     end
 


### PR DESCRIPTION
Log to cloud-watch so that collector and operations logs show up in kibana.