### PR TITLE
Changed parsing of kafka message's event name

### DIFF
--- a/lib/topological_inventory/ansible_tower/operations/processor.rb
+++ b/lib/topological_inventory/ansible_tower/operations/processor.rb
@@ -9,7 +9,7 @@ module TopologicalInventory
         include Logging
 
         def self.process!(message)
-          model, method = message.headers['message_type'].to_s.split(".")
+          model, method = message.message.to_s.split(".")
           new(model, method, message.payload).process
         end
 


### PR DESCRIPTION
It seems that `headers['message_type']` has been removed