### PR TITLE
Remove duplicite method

### DIFF
--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -100,10 +100,4 @@ module TopologicalInventory::AnsibleTower
       "AnsibleTower"
     end
   end
-
-  # Used for Save & Sweep Inventory
-  def inventory_name
-    "AnsibleTower"
-  end
 end
-


### PR DESCRIPTION
It seems like some manual merge mistake, anyway `TopologicalInventory::AnsibleTower.inventory_name` is not used