### PR TITLE
Collecting Artifacts and ExtraVars

### DIFF
--- a/lib/topological_inventory/ansible_tower/parser/service_instance.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_instance.rb
@@ -18,6 +18,13 @@ module TopologicalInventory::AnsibleTower
           :finished => job.finished,
           :status   => job.status
         }
+        # launch variables set either manually, by survey values or artifacts from previous job in workflow
+        extra_vars = job.extra_vars_hash
+        extra[:extra_vars] = extra_vars if extra_vars.present?
+        if job.type == 'job'
+          artifacts = job.artifacts.to_s
+          extra[:artifacts] = YAML.safe_load(artifacts) if artifacts.present? && artifacts != '{}' # Artifacts are set by set_stats:data in playbook (Jobs only)
+        end
 
         collections.service_instances.build(
           parse_base_item(job).merge(


### PR DESCRIPTION
TPINVTRY-730

Data set in playbooks byt the `set_stats` command are saved in Job as "artifacts".
On target Jobs, they are set as `extra_vars`.

`artifacts` are not propagated from Jobs to Workflows, so consumer Job connected by edge from Workflow containing Job with artifacts will fail => `set_stats` for Workflows is not applicable unlike task requested.

`extra_vars` for workflows connected by edge from job with artifacts and for their children are computed by tower and accessible by API. 
