### PR TITLE
[WIP] Proxy requests

### DIFF
--- a/bin/ansible_tower-collector
+++ b/bin/ansible_tower-collector
@@ -46,6 +46,12 @@ def parse_args
         :type => :string, :default => ENV["INGRESS_API"] || "http://localhost:9292"
     opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics",
         :type => :integer, :default => (ENV["METRICS_PORT"] || 9394).to_i
+    opt :receptor_node_id, "ID of on-premise Receptor Node",
+        :type => :string, :default => ENV["RECEPTOR_NODE_ID"]
+    opt :proxy_scheme, "Proxy scheme",
+        :type => :string, :default => ENV["PROXY_SCHEME"] || 'http'
+    opt :proxy_host, "Proxy host",
+        :type => :string, :default => ENV["PROXY_HOST"]
   end
 end
 
@@ -73,7 +79,12 @@ TopologicalInventoryIngressApiClient.configure.host   = "#{ingress_api_uri.host}
 begin
   metrics = TopologicalInventory::AnsibleTower::Collector::ApplicationMetrics.new(args[:metrics_port])
   if args[:config].nil?
-    collector = TopologicalInventory::AnsibleTower::Collector.new(args[:source], "#{args[:scheme]}://#{args[:host]}", args[:user], args[:password], metrics)
+    collector = TopologicalInventory::AnsibleTower::Collector.new(args[:source],
+                                                                  "#{args[:scheme]}://#{args[:host]}",
+                                                                  args[:user], args[:password],
+                                                                  metrics,
+                                                                  :proxy_hostname => "#{args[:proxy_scheme]}://#{args[:proxy_host]}",
+                                                                  :receptor_node_id => args[:receptor_node_id])
     collector.collect!
   else
     pool = TopologicalInventory::AnsibleTower::CollectorsPool.new(args[:config], metrics)

--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -11,14 +11,17 @@ module TopologicalInventory::AnsibleTower
     require "topological_inventory/ansible_tower/collector/service_catalog"
     include TopologicalInventory::AnsibleTower::Collector::ServiceCatalog
 
-    def initialize(source, tower_hostname, tower_user, tower_passwd, metrics, poll_time = 60)
+    def initialize(source, tower_hostname, tower_user, tower_passwd, metrics,
+                   poll_time: 60, proxy_hostname:, receptor_node_id:)
       super(source, :poll_time => poll_time)
 
       self.connection_manager = TopologicalInventory::AnsibleTower::Connection.new
+      self.metrics = metrics
+      self.proxy_hostname = proxy_hostname
+      self.receptor_node_id = receptor_node_id
       self.tower_hostname = tower_hostname
       self.tower_user = tower_user
       self.tower_passwd = tower_passwd
-      self.metrics = metrics
     end
 
     def collect!
@@ -35,7 +38,7 @@ module TopologicalInventory::AnsibleTower
     private
 
     attr_accessor :connection_manager, :tower_hostname, :tower_user, :tower_passwd,
-                  :metrics
+                  :metrics, :proxy_hostname, :receptor_node_id
 
     def endpoint_types
       %w[service_catalog]
@@ -47,7 +50,9 @@ module TopologicalInventory::AnsibleTower
 
     # Connection to endpoint (for each entity type the same)
     def connection_for_entity_type(_entity_type)
-      connection_manager.connect(tower_hostname, tower_user, tower_passwd)
+      connection_manager.connect(tower_hostname, tower_user, tower_passwd,
+                                 :proxy_hostname => proxy_hostname,
+                                 :receptor_node_id => receptor_node_id)
     end
 
     # Thread's main for collecting one entity type's data

--- a/lib/topological_inventory/ansible_tower/collector/service_catalog.rb
+++ b/lib/topological_inventory/ansible_tower/collector/service_catalog.rb
@@ -62,8 +62,6 @@ module TopologicalInventory::AnsibleTower
         TopologicalInventory::AnsibleTower::Iterator.new(fnc, "Couldn't fetch 'service_instance_nodes' of service catalog.")
       end
 
-      # TODO: It seems that each request are sent twice in ansible_tower_client
-      # But don't know why yet
       def get_service_plan(template)
         template.survey_spec_hash if template.survey_enabled
       end


### PR DESCRIPTION
"Proxy" requests are needed to on-premise tower communication through receptor.

Receptor controller doesn't support pairing requests with responses, so multithreading has to be solved with mutex on proxy side, but it'll cause slow responses.

Requests from collector can't be built as proxy requests, because Puma server on receptor-proxy app crashes during parsing (should be solved i.e. by using Go lang), so target host is provided by http header and parsed by proxy rack server.

---

https://github.com/slemrmartin/receptor-proxy/blob/master/lib/receptor_proxy/server.rb

- [ ] **depends on** https://github.com/ansible/ansible_tower_client_ruby/pull/134