### PR TITLE
Operations: initial Running status

### DIFF
--- a/lib/topological_inventory/ansible_tower/operations/core/service_order_mixin.rb
+++ b/lib/topological_inventory/ansible_tower/operations/core/service_order_mixin.rb
@@ -11,6 +11,8 @@ module TopologicalInventory
             task_id, service_offering_id, service_plan_id, order_params = params.values_at(
               "task_id", "service_offering_id", "service_plan_id", "order_params")
 
+            update_task(task_id, :state => "running", :status => "ok", :context => {})
+
             service_plan          = topology_api_client.show_service_plan(service_plan_id.to_s) if service_plan_id
             service_offering_id ||= service_plan.service_offering_id
             service_offering      = topology_api_client.show_service_offering(service_offering_id.to_s)

--- a/lib/topological_inventory/ansible_tower/operations/service_offering.rb
+++ b/lib/topological_inventory/ansible_tower/operations/service_offering.rb
@@ -23,6 +23,8 @@ module TopologicalInventory
           task_id, service_offering_id, service_params = params.values_at("task_id", "service_offering_id", "service_parameters")
           service_params ||= {}
 
+          update_task(task_id, :state => "running", :status => "ok", :context => {})
+
           service_offering = topology_api_client.show_service_offering(service_offering_id.to_s)
           prompted_inventory_id = service_params['prompted_inventory_id']
 

--- a/spec/operations/service_offering/applied_inventories_spec.rb
+++ b/spec/operations/service_offering/applied_inventories_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::ServiceOffering d
         subject.params['service_parameters']['prompted_inventory_id'] = workflow_definition[:prompted_inventory].id if workflow_definition[:prompted_inventory]
 
         expect(subject).to receive(:update_task).with(nil,
+                                                      :state => "running",
+                                                      :status => "ok",
+                                                      :context => {})
+        expect(subject).to receive(:update_task).with(nil,
                                                       :state => "completed",
                                                       :status => "ok",
                                                       :context => { :applied_inventories => match_array(workflow_definition[:applied_inventories].map(&:id))})

--- a/spec/operations/service_offering/order_spec.rb
+++ b/spec/operations/service_offering/order_spec.rb
@@ -27,6 +27,8 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::ServiceOffering d
     end
 
     it "orders the service plan" do
+      expect(subject).to receive(:update_task).with(1, :state => "running", :status => "ok", :context => {})
+
       topology_api_client = double
       expect(topology_api_client).to receive(:show_service_offering).with("1")
         .and_return(service_offering)

--- a/spec/operations/service_plan_spec.rb
+++ b/spec/operations/service_plan_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::ServicePlan do
     end
 
     it "orders the service plan" do
+      expect(subject).to receive(:update_task).with(1, :state => "running", :status => "ok", :context => {})
+
       topology_api_client = double
       expect(topology_api_client).to receive(:show_service_plan).with("1")
         .and_return(service_plan)


### PR DESCRIPTION
This PR adds Task's update to "running" status at the beginning of "applied inventories" and "service order" operations. To log that operation is received from Kafka. 