### PR TITLE
Task's update fix, empty context not permitted

### DIFF
--- a/lib/topological_inventory/ansible_tower/operations/core/service_order_mixin.rb
+++ b/lib/topological_inventory/ansible_tower/operations/core/service_order_mixin.rb
@@ -11,7 +11,7 @@ module TopologicalInventory
             task_id, service_offering_id, service_plan_id, order_params = params.values_at(
               "task_id", "service_offering_id", "service_plan_id", "order_params")
 
-            update_task(task_id, :state => "running", :status => "ok", :context => {})
+            update_task(task_id, :state => "running", :status => "ok")
 
             service_plan          = topology_api_client.show_service_plan(service_plan_id.to_s) if service_plan_id
             service_offering_id ||= service_plan.service_offering_id

--- a/lib/topological_inventory/ansible_tower/operations/core/topology_api_client.rb
+++ b/lib/topological_inventory/ansible_tower/operations/core/topology_api_client.rb
@@ -12,8 +12,10 @@ module TopologicalInventory
               end
           end
 
-          def update_task(task_id, state:, status:, context:)
-            task = TopologicalInventoryApiClient::Task.new("state" => state, "status" => status, "context" => context)
+          def update_task(task_id, state:, status:, context: nil)
+            params = {"state" => state, "status" => status }
+            params["context"] = context if context
+            task = TopologicalInventoryApiClient::Task.new(params)
             topology_api_client.update_task(task_id, task)
           end
         end

--- a/lib/topological_inventory/ansible_tower/operations/service_offering.rb
+++ b/lib/topological_inventory/ansible_tower/operations/service_offering.rb
@@ -23,7 +23,7 @@ module TopologicalInventory
           task_id, service_offering_id, service_params = params.values_at("task_id", "service_offering_id", "service_parameters")
           service_params ||= {}
 
-          update_task(task_id, :state => "running", :status => "ok", :context => {})
+          update_task(task_id, :state => "running", :status => "ok")
 
           service_offering = topology_api_client.show_service_offering(service_offering_id.to_s)
           prompted_inventory_id = service_params['prompted_inventory_id']

--- a/spec/operations/service_offering/applied_inventories_spec.rb
+++ b/spec/operations/service_offering/applied_inventories_spec.rb
@@ -26,8 +26,7 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::ServiceOffering d
 
         expect(subject).to receive(:update_task).with(nil,
                                                       :state => "running",
-                                                      :status => "ok",
-                                                      :context => {})
+                                                      :status => "ok")
         expect(subject).to receive(:update_task).with(nil,
                                                       :state => "completed",
                                                       :status => "ok",

--- a/spec/operations/service_offering/order_spec.rb
+++ b/spec/operations/service_offering/order_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::ServiceOffering d
     end
 
     it "orders the service plan" do
-      expect(subject).to receive(:update_task).with(1, :state => "running", :status => "ok", :context => {})
+      expect(subject).to receive(:update_task).with(1, :state => "running", :status => "ok")
 
       topology_api_client = double
       expect(topology_api_client).to receive(:show_service_offering).with("1")

--- a/spec/operations/service_plan_spec.rb
+++ b/spec/operations/service_plan_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::ServicePlan do
     end
 
     it "orders the service plan" do
-      expect(subject).to receive(:update_task).with(1, :state => "running", :status => "ok", :context => {})
+      expect(subject).to receive(:update_task).with(1, :state => "running", :status => "ok")
 
       topology_api_client = double
       expect(topology_api_client).to receive(:show_service_plan).with("1")


### PR DESCRIPTION
Topological API's `body_params['context']` can't be empty hash for `permit` operation