### PR TITLE
Updated Sources API calls to be identified as org_admin calls.

### DIFF
--- a/lib/topological_inventory/ansible_tower/operations/source.rb
+++ b/lib/topological_inventory/ansible_tower/operations/source.rb
@@ -60,7 +60,7 @@ module TopologicalInventory
         end
 
         def identity
-          @identity ||= { "x-rh-identity" => Base64.strict_encode64({ "identity" => { "account_number" => params["external_tenant"] }}.to_json) }
+          @identity ||= { "x-rh-identity" => Base64.strict_encode64({ "identity" => { "account_number" => params["external_tenant"], "user" => { "is_org_admin" => true }}}.to_json) }
         end
 
         def api_client

--- a/spec/operations/source_spec.rb
+++ b/spec/operations/source_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe(TopologicalInventory::AnsibleTower::Operations::Source) do
     let(:host_url) { "https://cloud.redhat.com" }
     let(:external_tenant) { "11001" }
     let(:identity) do
-      { "x-rh-identity" => Base64.strict_encode64({ "identity" => { "account_number" => external_tenant } }.to_json) }
+      { "x-rh-identity" => Base64.strict_encode64({ "identity" => { "account_number" => external_tenant, "user" => { "is_org_admin" => true } } }.to_json) }
     end
     let(:headers) { {"Content-Type" => "application/json"}.merge(identity) }
 


### PR DESCRIPTION
- identity header used for the sources api now have the is_org_admin flag set to true.