### PR TITLE
[WIP] Using thread pool for memory optimization

### DIFF
--- a/lib/topological_inventory/ansible_tower/collectors_pool.rb
+++ b/lib/topological_inventory/ansible_tower/collectors_pool.rb
@@ -32,7 +32,8 @@ module TopologicalInventory::AnsibleTower
       url = URI::Generic.build(:scheme => source.scheme.to_s.strip.presence || 'https',
                                :host   => source.host.to_s.strip,
                                :port   => source.port.to_s.strip)
-      TopologicalInventory::AnsibleTower::Collector.new(source.source, url.to_s, secret["username"], secret["password"], metrics)
+      TopologicalInventory::AnsibleTower::Collector.new(source.source, url.to_s, secret["username"], secret["password"], metrics,
+                                                        :collector_threads => collector_threads)
     end
   end
 end


### PR DESCRIPTION
AnsibleTower Collector uses 1 thread per entity type. In multi-source mode it uses 1 thread per source.

Which means `<number of sources> * <number of entity types>` threads.

By using ThreadPool we can significantly increase number of Sources processed by 1 collector with constant memory usage.

---

* [ ] **depends on** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/11