### PR TITLE
Standalone mode switch for multisource ThreadPool

### DIFF
--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -11,14 +11,15 @@ module TopologicalInventory::AnsibleTower
     require "topological_inventory/ansible_tower/collector/service_catalog"
     include TopologicalInventory::AnsibleTower::Collector::ServiceCatalog
 
-    def initialize(source, tower_hostname, tower_user, tower_passwd, metrics, poll_time = 60)
-      super(source, :poll_time => poll_time)
+    def initialize(source, tower_hostname, tower_user, tower_passwd, metrics,
+                   poll_time: 60, standalone_mode: true)
+      super(source, :poll_time => poll_time, :standalone_mode => standalone_mode)
 
       self.connection_manager = TopologicalInventory::AnsibleTower::Connection.new
-      self.tower_hostname = tower_hostname
-      self.tower_user = tower_user
-      self.tower_passwd = tower_passwd
-      self.metrics = metrics
+      self.tower_hostname     = tower_hostname
+      self.tower_user         = tower_user
+      self.tower_passwd       = tower_passwd
+      self.metrics            = metrics
     end
 
     def collect!
@@ -28,7 +29,8 @@ module TopologicalInventory::AnsibleTower
         collector_threads.each_value do |thread|
           thread.join
         end
-        sleep(poll_time)
+
+        standalone_mode ? sleep(poll_time) : stop
       end
     end
 

--- a/lib/topological_inventory/ansible_tower/collectors_pool.rb
+++ b/lib/topological_inventory/ansible_tower/collectors_pool.rb
@@ -6,7 +6,7 @@ module TopologicalInventory::AnsibleTower
   class CollectorsPool < TopologicalInventory::Providers::Common::CollectorsPool
     include Logging
 
-    def initialize(config_name, metrics, poll_time: 10)
+    def initialize(config_name, metrics)
       super
     end
 
@@ -32,7 +32,7 @@ module TopologicalInventory::AnsibleTower
       url = URI::Generic.build(:scheme => source.scheme.to_s.strip.presence || 'https',
                                :host   => source.host.to_s.strip,
                                :port   => source.port.to_s.strip)
-      TopologicalInventory::AnsibleTower::Collector.new(source.source, url.to_s, secret["username"], secret["password"], metrics)
+      TopologicalInventory::AnsibleTower::Collector.new(source.source, url.to_s, secret["username"], secret["password"], metrics, :standalone_mode => false)
     end
   end
 end


### PR DESCRIPTION
MultiSource mode will schedule running of collectors. It means in this mode collecting isn't run i the loop.

---

-  **depends on [mutual]** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/11