### PR TITLE
Operations: Handling unknown ops

### DIFF
--- a/spec/operations/processor_spec.rb
+++ b/spec/operations/processor_spec.rb
@@ -1,0 +1,25 @@
+require "topological_inventory/ansible_tower/operations/processor"
+
+RSpec.describe TopologicalInventory::AnsibleTower::Operations::Processor do
+  context "#process" do
+    it "updates task with not_implemented error if operation not supported" do
+      # Non-existing class
+      task_id = '1'
+      processor = described_class.new('SomeModel', 'some_method', {'params' => {'task_id' => task_id}})
+      expect(processor).to receive(:update_task).with(task_id,
+                                                      :state   => 'completed',
+                                                      :status  => 'error',
+                                                      :context => {:error => "SomeModel#some_method not implemented"})
+      processor.process
+
+      # Non-existing method
+      task_id = '2'
+      processor = described_class.new('ServiceOffering', 'some_method', {'params' => {'task_id' => task_id}})
+      expect(processor).to receive(:update_task).with(task_id,
+                                                      :state   => 'completed',
+                                                      :status  => 'error',
+                                                      :context => {:error => "ServiceOffering#some_method not implemented"})
+      processor.process
+    end
+  end
+end


### PR DESCRIPTION
Unknown operations sent to operations workers are now logged as Warn:"Not implemented" and Task is updated to "error:completed", if provided. 