### PR TITLE
Reduce the timout to open a connection to 10 sec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem "activesupport", "~> 5.2.2"
-gem "ansible_tower_client", "~> 0.19.0"
+gem "ansible_tower_client", "~> 0.21.0"
 gem "cloudwatchlogger",   "~> 0.2"
 gem "concurrent-ruby"
 gem "manageiq-loggers",   "~> 0.4.0", ">= 0.4.2"

--- a/lib/topological_inventory/ansible_tower/connection.rb
+++ b/lib/topological_inventory/ansible_tower/connection.rb
@@ -5,13 +5,14 @@ module TopologicalInventory::AnsibleTower
   class Connection
     include Logging
 
-    def connect(base_url, username, password, verify_ssl: ::OpenSSL::SSL::VERIFY_NONE)
+    def connect(base_url, username, password, verify_ssl: ::OpenSSL::SSL::VERIFY_NONE, open_timeout: 10)
       AnsibleTowerClient.logger = self.logger
       AnsibleTowerClient::Connection.new(
         :base_url   => api_url(base_url),
         :username   => username,
         :password   => password,
-        :verify_ssl => verify_ssl
+        :verify_ssl => verify_ssl,
+        :request    => {:open_timeout => open_timeout}
       )
     end
 


### PR DESCRIPTION
If an attempt to connect to an Ansible Tower source hangs the default
open_timeout of 60 seconds was starving the operations worker causing
availability checks to appear to never complete.

Depends on: https://github.com/ansible/ansible_tower_client_ruby/pull/140 being released

Relates to JIRA: TPINVTRY-851