### PR TITLE
Use ansible tower client 0.21.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ plugin 'bundler-inject', '~> 1.1'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem "activesupport", "~> 5.2.2"
-gem "ansible_tower_client", "~> 0.19.0"
+gem "ansible_tower_client", "~> 0.21.0"
 gem "cloudwatchlogger",   "~> 0.2"
 gem "concurrent-ruby"
 gem "manageiq-loggers",   "~> 0.4.0", ">= 0.4.2"


### PR DESCRIPTION
for https://github.com/RedHatInsights/topological_inventory-core/issues/168 
we need support for v2 API credential objects which is in https://github.com/ansible/ansible_tower_client_ruby/commit/5ca5a7ba3f9d01277b7d9a9a088e033ac80aa9d7

so I set it to latest.


cc @slemrmartin 
