### PR TITLE
Add external_url logging to collector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "rest-client", "~>2.0"
 gem "sources-api-client", "~> 1.0"
 gem "topological_inventory-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 1.0.0"
+gem "topological_inventory-providers-common", "~> 1.0.1"
 group :development, :test do
   gem "rspec"
   gem "simplecov"

--- a/lib/topological_inventory/ansible_tower/collector/service_catalog.rb
+++ b/lib/topological_inventory/ansible_tower/collector/service_catalog.rb
@@ -3,6 +3,7 @@ module TopologicalInventory::AnsibleTower
     module ServiceCatalog
       def get_service_credentials(connection)
         fnc = lambda do |&block|
+          log_external_url("#{connection_manager.api_url(tower_hostname)}/#{connection.api.credentials.klass.endpoint}")
           enumerator = connection.api.credentials.all(:page_size => limits[:service_credentials])
           enumerator.each do |service_credential|
             block.call(service_credential)
@@ -13,6 +14,7 @@ module TopologicalInventory::AnsibleTower
 
       def get_service_credential_types(connection)
         fnc = lambda do |&block|
+          log_external_url("#{connection_manager.api_url(tower_hostname)}/#{connection.api.credential_types.klass.endpoint}")
           enumerator = connection.api.credential_types.all(:page_size => limits[:service_credential_types])
           enumerator.each do |service_credential_type|
             block.call(service_credential_type)
@@ -23,6 +25,7 @@ module TopologicalInventory::AnsibleTower
 
       def get_service_inventories(connection)
         fnc = lambda do |&block|
+          log_external_url("#{connection_manager.api_url(tower_hostname)}/#{connection.api.inventories.klass.endpoint}")
           enumerator = connection.api.inventories.all(:page_size => limits[:service_inventories])
           enumerator.each do |inventory|
             block.call(inventory)
@@ -33,6 +36,8 @@ module TopologicalInventory::AnsibleTower
 
       def get_service_offerings(connection)
         fnc = lambda do |&block|
+          log_external_url("#{connection_manager.api_url(tower_hostname)}/#{connection.api.job_templates.klass.endpoint}")
+          log_external_url("#{connection_manager.api_url(tower_hostname)}/#{connection.api.workflow_job_templates.klass.endpoint}")
           {:job_template          => connection.api.job_templates.all(:page_size => limits[:service_offerings]),
            :workflow_job_template => connection.api.workflow_job_templates.all(:page_size => limits[:service_offerings])}.each_pair do |type, enumerator|
             enumerator.each do |template|
@@ -49,6 +54,7 @@ module TopologicalInventory::AnsibleTower
 
       def get_service_offering_nodes(connection)
         fnc = lambda do |&block|
+          log_external_url("#{connection_manager.api_url(tower_hostname)}/#{connection.api.workflow_job_template_nodes.klass.endpoint}")
           enumerator = connection.api.workflow_job_template_nodes.all(:page_size => limits[:service_offering_nodes])
           enumerator.each do |service_offering_node|
             credentials = connection.api.workflow_job_template_nodes.find_all_by_url(service_offering_node.related.credentials)
@@ -60,6 +66,8 @@ module TopologicalInventory::AnsibleTower
 
       def get_service_instances(connection)
         fnc = lambda do |&block|
+          log_external_url("#{connection_manager.api_url(tower_hostname)}/#{connection.api.jobs.klass.endpoint}")
+          log_external_url("#{connection_manager.api_url(tower_hostname)}/#{connection.api.workflow_jobs.klass.endpoint}")
           {:job          => connection.api.jobs.all(:page_size => limits[:service_instances]),
            :workflow_job => connection.api.workflow_jobs.all(:page_size => limits[:service_instances])}.each_pair do |type, enumerator|
             enumerator.each do |job|
@@ -75,6 +83,7 @@ module TopologicalInventory::AnsibleTower
 
       def get_service_instance_nodes(connection)
         fnc = lambda do |&block|
+          log_external_url("#{connection_manager.api_url(tower_hostname)}/#{connection.api.workflow_job_nodes.klass.endpoint}")
           enumerator = connection.api.workflow_job_nodes.all(:page_size => limits[:service_instance_nodes])
           enumerator.each do |service_instance_node|
             credentials = connection.api.workflow_job_nodes.find_all_by_url(service_instance_node.related.credentials)


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-881
This is the tower collector implementation for this ticket. 

Looking for input on this. currently it logs like so: 
![image](https://user-images.githubusercontent.com/5856504/78723586-5531cd00-78f1-11ea-9d5e-938f096dc42c.png)

Potential things I may be missing:
- should we add parameters to the logging?
- ~~maybe I could move this to the base collector class since it's just one method and it could be used across all of the collectors, that way we can just call this moethod in each `get_#{resource_type}` method call.~~ https://github.com/RedHatInsights/topological_inventory-providers-common/pull/18

cc @gmcculloug @slemrmartin 

----

EDIT:
**Depends on**: https://github.com/RedHatInsights/topological_inventory-providers-common/pull/18