### PR TITLE
[WIP] Add heartbeat check for operations worker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,10 @@ gem "sources-api-client", "~> 1.0"
 gem "topological_inventory-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
 gem "topological_inventory-providers-common", "~> 1.0.1"
+
 group :development, :test do
   gem "rspec"
   gem "simplecov"
+  gem "timecop"
   gem "webmock"
 end

--- a/bin/ansible_tower-operations
+++ b/bin/ansible_tower-operations
@@ -1,10 +1,12 @@
 #!/usr/bin/env ruby
 
 $LOAD_PATH << File.expand_path("../lib", __dir__)
+
 require "bundler/setup"
 require "active_support/core_ext/object/blank"
 require "optimist"
 require "topological_inventory/ansible_tower/operations/worker"
+require "topological_inventory/providers/common/heartbeat"
 
 def parse_args
   Optimist.options do
@@ -42,6 +44,15 @@ end
 SourcesApiClient.configure do |config|
   config.scheme = args[:sources_scheme] || "http"
   config.host   = "#{args[:sources_host]}:#{args[:sources_port]}"
+end
+
+ActiveSupport::Notifications.subscribe(/.*heartbeat\.consumer\.kafka.*$/) do |*options|
+  messaging_options = TopologicalInventory::AnsibleTower::Operations::Worker.default_messaging_opts
+  event = ActiveSupport::Notifications::Event.new(*options)
+  if messaging_options[:group_ref] == event.payload[:group_id] && messaging_options[:client_ref] == event.payload[:client_id]
+    heartbeat = TopologicalInventory::Providers::Common::Heartbeat.new("operations-kafka")
+    heartbeat.touch_heartbeat_file
+  end
 end
 
 begin

--- a/bin/heartbeat_check_collector
+++ b/bin/heartbeat_check_collector
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+require "bundler/setup"
+require "topological_inventory/providers/common/heartbeat"
+
+HEARTBEATS = %w[collector-standalone collector_pool]
+
+exit_status = HEARTBEATS.any? { |name| TopologicalInventory::Providers::Common::Heartbeat.check(name) }
+
+exit_status = exit_status ? 0 : 1
+
+exit exit_status

--- a/bin/heartbeat_check_operations
+++ b/bin/heartbeat_check_operations
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+
+require "bundler/setup"
+require "topological_inventory/providers/common/heartbeat"
+
+HEARTBEATS = %w[operations operations-kafka]
+
+exit_status = HEARTBEATS.any? { |name| TopologicalInventory::Providers::Common::Heartbeat.check(name) }
+
+exit_status = exit_status ? 0 : 1
+
+exit exit_status

--- a/lib/topological_inventory/ansible_tower/collectors_pool.rb
+++ b/lib/topological_inventory/ansible_tower/collectors_pool.rb
@@ -28,11 +28,11 @@ module TopologicalInventory::AnsibleTower
       missing_data.empty?
     end
 
-    def new_collector(source, secret)
+    def new_collector(source, secret, heartbeat = nil)
       url = URI::Generic.build(:scheme => source.scheme.to_s.strip.presence || 'https',
                                :host   => source.host.to_s.strip,
                                :port   => source.port.to_s.strip)
-      TopologicalInventory::AnsibleTower::Collector.new(source.source, url.to_s, secret["username"], secret["password"], metrics, :standalone_mode => false)
+      TopologicalInventory::AnsibleTower::Collector.new(source.source, url.to_s, secret["username"], secret["password"], metrics, :standalone_mode => false, :heartbeat_queue => heartbeat)
     end
   end
 end

--- a/lib/topological_inventory/ansible_tower/operations/core/service_order_mixin.rb
+++ b/lib/topological_inventory/ansible_tower/operations/core/service_order_mixin.rb
@@ -16,6 +16,7 @@ module TopologicalInventory
             update_task(task_id, :state => "running", :status => "ok")
 
             service_plan          = topology_api_client.show_service_plan(service_plan_id.to_s) if service_plan_id
+
             service_offering_id ||= service_plan.service_offering_id
             service_offering      = topology_api_client.show_service_offering(service_offering_id.to_s)
 
@@ -26,6 +27,7 @@ module TopologicalInventory
 
             logger.info("ServiceOffering#order: Task(id: #{task_id}): Ordering ServiceOffering(id: #{service_offering.id}, source_ref: #{service_offering.source_ref}): Launching Job...")
             job = client.order_service(job_type, service_offering.source_ref, order_params)
+
             logger.info("ServiceOffering#order: Task(id: #{task_id}): Ordering ServiceOffering(id: #{service_offering.id}, source_ref: #{service_offering.source_ref}): Job(:id #{job&.id}) has launched.")
 
             context = {

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -4,16 +4,45 @@ RSpec.describe TopologicalInventory::AnsibleTower::Collector do
   let(:client) { double('Ingress API Client')}
 
   subject do
+    metrics = double("Metrics")
+    allow(metrics).to receive(:record_error)
     described_class.new(source_uid,
                         'tower.example.com',
                         'user',
                         'passwd',
-                        nil)
-
+                        metrics, poll_time: 0)
   end
+
+  let(:connection) { double("Connection") }
+
+  let(:entity_types) { subject.send(:service_catalog_entity_types) }
 
   before do
     allow(subject).to receive(:logger).and_return(logger)
     allow(subject).to receive(:ingress_api_client).and_return(client)
+    parser = double(TopologicalInventory::AnsibleTower::Parser)
+    allow(parser).to receive(:collections).and_return({})
+
+    allow(subject).to receive(:sweep_inventory)
+    allow(TopologicalInventory::AnsibleTower::Parser).to receive(:new).with(tower_url: 'tower.example.com').and_return(parser)
+
+    entity_types.each do |entity|
+      allow(subject).to receive(:connection_for_entity_type).with(entity).and_return(connection)
+    end
+  end
+
+  it "calls heartbeat method during collection" do
+    entity_types.each do |entity|
+      method = "get_#{entity}"
+      allow(subject).to receive(method).with(connection).and_return([])
+    end
+
+    allow(subject).to receive(:sleep).with(0) do |_|
+      subject.stop
+    end
+
+    expect(subject.send(:heartbeat_queue)).to receive(:run_thread_with_timeout).exactly(8)
+
+    subject.collect!
   end
 end

--- a/spec/operations/worker_spec.rb
+++ b/spec/operations/worker_spec.rb
@@ -23,6 +23,8 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::Worker do
         .with(hash_including(:service => operations_topic)).and_yield(message)
       expect(TopologicalInventory::AnsibleTower::Operations::Processor)
         .to receive(:process!).with(message)
+      expect(subject.send(:current_heartbeat)).to receive(:run_thread_with_timeout)
+
       subject.run
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require "helpers/applied_inventories/methods"
 
 require "rspec"
 require "webmock/rspec"
+require "timecop"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Included:

Needed:

- [ ] (https://github.com/RedHatInsights/topological_inventory-providers-common/pull/17)

- added script to check whether heartbeat files are expired and this script will be used in configuration:
 - `bin/heartbeat_check_operations`
 - `bin/heartbeat_check_collector`

Operations:

- heartbeat ticks are in Kafka notification (when we are waiting for message in Kafka)
- in ordering (process - maybe this is not needed it is avoid some delay in network requests)

Collector:
- heartbeat tick is after we fetch data from collections

@miq-bot assign @slemrmartin 



