### PR TITLE
Setting up CodeClimate - Coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem "topological_inventory-ingress_api-client", "~> 1.0.1"
 gem "topological_inventory-providers-common", "~> 1.0.1"
 group :development, :test do
   gem "rspec"
-  gem "simplecov"
+  gem 'rubocop', "~>0.69.0"
+  gem 'rubocop-performance', "~>1.3"
+  gem "simplecov", "~> 0.17.1"
   gem "webmock"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+if ENV['CI']
+  require 'simplecov'
+  SimpleCov.start
+end
+
 require "bundler/setup"
 require "topological_inventory/ansible_tower/collectors_pool"
 


### PR DESCRIPTION
Updating the `Gemfile` and `Spec_helper` files to enable CodeClimate - Coverage.