### PR TITLE
Availability check: "last_checked_at" and "last_available_at" update

### DIFF
--- a/lib/topological_inventory/ansible_tower/operations/source.rb
+++ b/lib/topological_inventory/ansible_tower/operations/source.rb
@@ -15,7 +15,7 @@ module TopologicalInventory
           :endpoint_not_found       => "Endpoint not found in Sources API",
         }.freeze
 
-        LAST_CHECKED_AT_THRESHOLD = 5 # minutes
+        LAST_CHECKED_AT_THRESHOLD = 5.minutes.freeze
 
         attr_accessor :params, :request_context, :source_id
 
@@ -58,7 +58,7 @@ module TopologicalInventory
         def checked_recently?
           return false if endpoint.nil?
 
-          checked_recently = endpoint.last_checked_at.present? && endpoint.last_checked_at >= LAST_CHECKED_AT_THRESHOLD.minutes.ago
+          checked_recently = endpoint.last_checked_at.present? && endpoint.last_checked_at >= LAST_CHECKED_AT_THRESHOLD.ago
           logger.info("Source#availability_check - Skipping, last check at #{endpoint.last_checked_at} [Source ID: #{source_id}] ") if checked_recently
 
           checked_recently

--- a/spec/operations/source_spec.rb
+++ b/spec/operations/source_spec.rb
@@ -24,94 +24,115 @@ RSpec.describe(TopologicalInventory::AnsibleTower::Operations::Source) do
       }
     end
 
-    let(:list_endpoints_response) { "{\"data\":[{\"default\":true,\"host\":\"10.0.0.1\",\"id\":\"#{endpoint_id}\",\"path\":\"/\",\"role\":\"ansible\",\"scheme\":\"https\",\"source_id\":\"#{source_id}\",\"tenant\":\"#{external_tenant}\"}]}"}
+    let(:list_endpoints_response) { "{\"data\":[{\"default\":true,\"host\":\"10.0.0.1\",\"id\":\"#{endpoint_id}\",\"path\":\"/\",\"role\":\"ansible\",\"scheme\":\"https\",\"source_id\":\"#{source_id}\",\"tenant\":\"#{external_tenant}\"}]}" }
     let(:list_endpoint_authentications_response) { "{\"data\":[{\"authtype\":\"username_password\",\"id\":\"#{authentication_id}\",\"resource_id\":\"#{endpoint_id}\",\"resource_type\":\"Endpoint\",\"username\":\"admin\",\"tenant\":\"#{external_tenant}\"}]}" }
     let(:list_endpoint_authentications_response_empty) { "{\"data\":[]}" }
     let(:internal_api_authentication_response) { "{\"authtype\":\"username_password\",\"id\":\"#{authentication_id}\",\"resource_id\":\"#{endpoint_id}\",\"resource_type\":\"Endpoint\",\"username\":\"admin\",\"tenant\":\"#{external_tenant}\",\"password\":\"xxx\"}" }
 
     subject { described_class.new(payload["params"]) }
 
-    it "updates Source and Endpoint when available" do
-      # GET
-      stub_get(:endpoint, list_endpoints_response)
-      stub_get(:authentication, list_endpoint_authentications_response)
-      stub_get(:password, internal_api_authentication_response)
+    context "when not checked recently" do
+      before do
+        allow(subject).to receive(:checked_recently?).and_return(false)
+      end
 
-      # PATCH
-      source_patch_body = {'availability_status' => described_class::STATUS_AVAILABLE}.to_json
-      endpoint_patch_body = {'availability_status' => described_class::STATUS_AVAILABLE, 'availability_status_error' => ''}.to_json
+      it "updates Source and Endpoint when available" do
+        # GET
+        stub_get(:endpoint, list_endpoints_response)
+        stub_get(:authentication, list_endpoint_authentications_response)
+        stub_get(:password, internal_api_authentication_response)
 
-      stub_patch(:source, source_patch_body)
-      stub_patch(:endpoint, endpoint_patch_body)
+        # PATCH
+        source_patch_body = {'availability_status' => described_class::STATUS_AVAILABLE, 'last_available_at' => subject.send(:check_time), 'last_checked_at' => subject.send(:check_time)}.to_json
+        endpoint_patch_body = {'availability_status' => described_class::STATUS_AVAILABLE, 'availability_status_error' => '', 'last_available_at' => subject.send(:check_time), 'last_checked_at' => subject.send(:check_time)}.to_json
 
-      # Check ---
-      expect(subject).to receive(:connection_check).and_return([described_class::STATUS_AVAILABLE, nil])
+        stub_patch(:source, source_patch_body)
+        stub_patch(:endpoint, endpoint_patch_body)
 
-      subject.availability_check
+        # Check ---
+        expect(subject).to receive(:connection_check).and_return([described_class::STATUS_AVAILABLE, nil])
 
-      assert_patch(:source, source_patch_body)
-      assert_patch(:endpoint, endpoint_patch_body)
+        subject.availability_check
+
+        assert_patch(:source, source_patch_body)
+        assert_patch(:endpoint, endpoint_patch_body)
+      end
+
+      it "updates Source and Endpoint when unavailable" do
+        # GET
+        stub_get(:endpoint, list_endpoints_response)
+        stub_get(:authentication, list_endpoint_authentications_response)
+        stub_get(:password, internal_api_authentication_response)
+
+        # PATCH
+        connection_error_message = "Some connection error"
+        source_patch_body        = {'availability_status' => described_class::STATUS_UNAVAILABLE, 'last_checked_at' => subject.send(:check_time)}.to_json
+        endpoint_patch_body      = {'availability_status' => described_class::STATUS_UNAVAILABLE, 'availability_status_error' => connection_error_message, 'last_checked_at' => subject.send(:check_time)}.to_json
+
+        stub_patch(:source, source_patch_body)
+        stub_patch(:endpoint, endpoint_patch_body)
+
+        # Check ---
+        expect(subject).to receive(:connection_check).and_return([described_class::STATUS_UNAVAILABLE, connection_error_message])
+
+        subject.availability_check
+
+        assert_patch(:source, source_patch_body)
+        assert_patch(:endpoint, endpoint_patch_body)
+      end
+
+      it "updates only Source to 'unavailable' status if Endpoint not found" do
+        # GET
+        stub_get(:endpoint, '')
+
+        # PATCH
+        source_patch_body = {'availability_status' => described_class::STATUS_UNAVAILABLE, 'last_checked_at' => subject.send(:check_time)}.to_json
+        stub_patch(:source, source_patch_body)
+
+        # Check
+        api_client = subject.send(:api_client)
+        expect(api_client).not_to receive(:update_endpoint)
+
+        subject.availability_check
+
+        assert_patch(:source, source_patch_body)
+      end
+
+      it "updates Source and Endpoint to 'unavailable' if Authentication not found" do
+        # GET
+        stub_get(:endpoint, list_endpoints_response)
+        stub_get(:authentication, list_endpoint_authentications_response_empty)
+
+        # PATCH
+        source_patch_body   = {'availability_status' => described_class::STATUS_UNAVAILABLE, 'last_checked_at' => subject.send(:check_time)}.to_json
+        endpoint_patch_body = {'availability_status' => described_class::STATUS_UNAVAILABLE, 'availability_status_error' => described_class::ERROR_MESSAGES[:authentication_not_found], 'last_checked_at' => subject.send(:check_time)}.to_json
+
+        stub_patch(:source, source_patch_body)
+        stub_patch(:endpoint, endpoint_patch_body)
+
+        # Check
+        expect(subject).not_to receive(:connection_check)
+        subject.availability_check
+
+        assert_patch(:source, source_patch_body)
+        assert_patch(:endpoint, endpoint_patch_body)
+      end
     end
 
-    it "updates Source and Endpoint when unavailable" do
-      # GET
-      stub_get(:endpoint, list_endpoints_response)
-      stub_get(:authentication, list_endpoint_authentications_response)
-      stub_get(:password, internal_api_authentication_response)
+    context "when checked recently" do
+      before do
+        allow(subject).to receive(:checked_recently?).and_return(true)
+      end
 
-      # PATCH
-      connection_error_message = "Some connection error"
-      source_patch_body = {'availability_status' => described_class::STATUS_UNAVAILABLE}.to_json
-      endpoint_patch_body = {'availability_status' => described_class::STATUS_UNAVAILABLE, 'availability_status_error' => connection_error_message}.to_json
+      it "doesn't do connection check" do
+        expect(subject).not_to receive(:connection_check)
+        expect(WebMock).not_to have_requested(:patch, "#{sources_api_url}/sources/#{source_id}")
+        expect(WebMock).not_to have_requested(:patch, "#{sources_api_url}/endpoints/#{endpoint_id}")
 
-      stub_patch(:source, source_patch_body)
-      stub_patch(:endpoint, endpoint_patch_body)
-
-      # Check ---
-      expect(subject).to receive(:connection_check).and_return([described_class::STATUS_UNAVAILABLE, connection_error_message])
-
-      subject.availability_check
-
-      assert_patch(:source, source_patch_body)
-      assert_patch(:endpoint, endpoint_patch_body)
+        subject.availability_check
+      end
     end
 
-    it "updates only Source to 'unavailable' status if Endpoint not found" do
-      # GET
-      stub_get(:endpoint, '')
-
-      # PATCH
-      source_patch_body = {'availability_status' => described_class::STATUS_UNAVAILABLE}.to_json
-      stub_patch(:source, source_patch_body)
-
-      # Check
-      api_client = subject.send(:api_client)
-      expect(api_client).not_to receive(:update_endpoint)
-
-      subject.availability_check
-
-      assert_patch(:source, source_patch_body)
-    end
-
-    it "updates Source and Endpoint to 'unavailable' if Authentication not found" do
-      # GET
-      stub_get(:endpoint, list_endpoints_response)
-      stub_get(:authentication, list_endpoint_authentications_response_empty)
-
-      # PATCH
-      source_patch_body = {'availability_status' => described_class::STATUS_UNAVAILABLE}.to_json
-      endpoint_patch_body = {'availability_status' => described_class::STATUS_UNAVAILABLE, 'availability_status_error' => described_class::ERROR_MESSAGES[:authentication_not_found]}.to_json
-
-      stub_patch(:source, source_patch_body)
-      stub_patch(:endpoint, endpoint_patch_body)
-
-      # Check
-      expect(subject).not_to receive(:connection_check)
-      subject.availability_check
-
-      assert_patch(:source, source_patch_body)
-      assert_patch(:endpoint, endpoint_patch_body)
-    end
 
     def stub_get(object_type, response)
       case object_type


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/sources-api/issues/206

Availability check checks the `Endpoint.last_checked_at` and skips new testing if last check was less than 5 minutes ago. 
This will prevent processing many availability checks with big kafka lag. 

---

- [x] **depends on** #95 (needs rebase after merge)

---

[TPINVTRY-944](https://projects.engineering.redhat.com/browse/TPINVTRY-944)
