### PR TITLE
Remove collection of `insights_credential` on service_inventory

### DIFF
--- a/lib/topological_inventory/ansible_tower/parser/service_inventory.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_inventory.rb
@@ -15,7 +15,6 @@ module TopologicalInventory::AnsibleTower
               "variables"                       => inventory.variables,
               "total_inventory_sources"         => inventory.total_inventory_sources,
               "inventory_sources_with_failures" => inventory.inventory_sources_with_failures,
-              "insights_credential"             => inventory.insights_credential,
               "pending_deletion"                => inventory.pending_deletion,
             }
           )


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-951

This will work (for now) to get past this - I can't find a good way to reproduce this for now, so this will get us past it for the time being. 

cc @syncrou @slemrmartin 