### PR TITLE
Respect Endpoint port setting on Operations

### DIFF
--- a/bin/ansible_tower-collector
+++ b/bin/ansible_tower-collector
@@ -22,6 +22,7 @@ require require_dev_path if File.exist?(require_dev_path)
 # --source      (ENV["SOURCE_UID"])      - core: Source.uid (manager for this collector)
 # --scheme      (ENV["ENDPOINT_SCHEME"]) - ansible tower scheme, https by default
 # --host        (ENV["ENDPOINT_HOST"])   - ansible tower url
+# --port        (ENV["ENDPOINT_PORT"])   - ansible tower port
 # --user        (ENV["AUTH_USERNAME"])   - credentials: username
 # --password    (ENV["AUTH_PASSWORD"])   - credentials: password
 # --ingress-api (ENV["INGRESS_API"])     - ingress api server, by default *localhost:9292*
@@ -38,6 +39,8 @@ def parse_args
         :type => :string, :default => ENV["ENDPOINT_SCHEME"] || 'https'
     opt :host, "IP address or hostname of the Ansible Tower REST API",
         :type => :string, :default => ENV["ENDPOINT_HOST"]
+    opt :port, "Port for Ansible Tower REST API",
+        :type => :integer, :default => (ENV["ENDPOINT_PORT"]&.to_i || 443)
     opt :user, "Username to AnsibleTower",
         :type => :string, :default => ENV["AUTH_USERNAME"]
     opt :password, "Password to Ansible Tower",
@@ -73,7 +76,7 @@ TopologicalInventoryIngressApiClient.configure.host   = "#{ingress_api_uri.host}
 begin
   metrics = TopologicalInventory::AnsibleTower::Collector::ApplicationMetrics.new(args[:metrics_port])
   if args[:config].nil?
-    collector = TopologicalInventory::AnsibleTower::Collector.new(args[:source], "#{args[:scheme]}://#{args[:host]}", args[:user], args[:password], metrics)
+    collector = TopologicalInventory::AnsibleTower::Collector.new(args[:source], "#{args[:scheme]}://#{args[:host]}:#{args[:port]}", args[:user], args[:password], metrics)
     collector.collect!
   else
     pool = TopologicalInventory::AnsibleTower::CollectorsPool.new(args[:config], metrics)

--- a/lib/topological_inventory/ansible_tower/operations/source.rb
+++ b/lib/topological_inventory/ansible_tower/operations/source.rb
@@ -12,13 +12,17 @@ module TopologicalInventory
 
         def connection_check
           connection = ::TopologicalInventory::AnsibleTower::Connection.new
-          connection = connection.connect(endpoint.host, authentication.username, authentication.password)
+          connection = connection.connect(full_hostname(endpoint), authentication.username, authentication.password)
           connection.api.version
 
           [STATUS_AVAILABLE, nil]
         rescue => e
           logger.availability_check("Failed to connect to Source id:#{source_id} - #{e.message}", :error)
           [STATUS_UNAVAILABLE, e.message]
+        end
+
+        def full_hostname(endpoint)
+          endpoint.host.tap { |host| host << ":#{endpoint.port}" if endpoint.port }
         end
       end
     end

--- a/spec/operations/source_spec.rb
+++ b/spec/operations/source_spec.rb
@@ -3,4 +3,40 @@ require File.join(Gem::Specification.find_by_name("topological_inventory-provide
 
 RSpec.describe(TopologicalInventory::AnsibleTower::Operations::Source) do
   it_behaves_like "availability_check" # in providers-common
+
+  context "#connection_check" do
+    let(:api_client) { instance_double(TopologicalInventory::Providers::Common::Operations::SourcesApiClient) }
+    let(:default_response) { {:status => 200, :body => {}.to_json, :headers => {}} }
+    let(:tower_host) { "test.tower.com" }
+
+    subject { described_class.new.send(:connection_check) }
+
+    before do
+      allow(TopologicalInventory::Providers::Common::Operations::SourcesApiClient).to receive(:new).and_return(api_client)
+      allow(api_client).to receive(:fetch_authentication).and_return(OpenStruct.new(:username => "test", :password => "xxx"))
+      allow(api_client).to receive(:fetch_default_endpoint).and_return(OpenStruct.new(:host => tower_host, :port => port))
+    end
+
+    context "with a port" do
+      let(:port) { 9443 }
+
+      it "reaches out on defined port" do
+        stub_request(:get, "https://test.tower.com:9443/api/v2/config/").to_return(**default_response)
+        subject
+
+        expect(a_request(:get, "https://test.tower.com:9443/api/v2/config/")).to have_been_made.at_least_once
+      end
+    end
+
+    context "without a port" do
+      let(:port) { nil }
+
+      it "does not have a port in the URL" do
+        stub_request(:get, "https://test.tower.com/api/v2/config/").to_return(**default_response)
+        subject
+
+        expect(a_request(:get, "https://test.tower.com/api/v2/config/")).to have_been_made.at_least_once
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1850116

cc @gmcculloug @syncrou @slemrmartin 

~~Not the direct cause of our issue - but did find this while debugging. The collector respects whatever port is configured in pool-mode but NOT in single-collector mode.~~

1. So after doing some digging, I found that the culprit is that on the Ansible Tower Operations Source class was failing to set up the host correctly from the sources endpoint response, it was ignoring the port. 

2. I also found that there was no CLI option for port - so I added that in a tiny commit as well. 