### PR TITLE
update cli queue_port option type to integer

### DIFF
--- a/bin/ansible_tower-collector
+++ b/bin/ansible_tower-collector
@@ -42,7 +42,7 @@ def parse_args
     opt :queue_host, "Kafka messaging: hostname or IP",
         :type => :string, :default => ENV["QUEUE_HOST"] || "localhost"
     opt :queue_port, "Kafka messaging: port",
-        :type => :string, :default => ENV["QUEUE_PORT"] || 9092
+        :type => :integer, :default => ENV["QUEUE_PORT"]&.to_i || 9092
   end
 end
 


### PR DESCRIPTION
Pods in CI are in crashloopbackoff I assume due to the dc's not having the queue_port value since they haven't been re-created. This will fix that. 
