### PR TITLE
Fixed WorkflowJobTemplate parsing

### DIFF
--- a/lib/topological_inventory/ansible_tower/parser/service_offering.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_offering.rb
@@ -6,25 +6,32 @@ module TopologicalInventory::AnsibleTower
 
         service_inventory = lazy_find(:service_inventories, :source_ref => template.inventory_id.to_s) if template.respond_to?(:inventory_id)
 
+        extra = {
+          :type                    => template_hash[:template_type],
+          :ask_variables_on_launch => template.ask_variables_on_launch,
+          :ask_inventory_on_launch => template.ask_inventory_on_launch,
+          :survey_enabled          => template.survey_enabled,
+        }
+
+        if template_hash[:template_type].to_s == 'job_template'
+          extra = extra.merge(
+            :ask_credential_on_launch => template.ask_credential_on_launch,
+            :ask_diff_mode_on_launch  => template.ask_diff_mode_on_launch,
+            :ask_job_type_on_launch   => template.ask_job_type_on_launch,
+            :ask_limit_on_launch      => template.ask_limit_on_launch,
+            :ask_skip_tags_on_launch  => template.ask_skip_tags_on_launch,
+            :ask_tags_on_launch       => template.ask_tags_on_launch,
+            :ask_verbosity_on_launch  => template.ask_verbosity_on_launch
+          )
+        end
+
         service_offering = collections.service_offerings.build(
           parse_base_item(template).merge(
             :source_ref        => template.id.to_s,
             :name              => template.name.to_s,
             :description       => template.description.to_s,
             :service_inventory => service_inventory,
-            :extra             => {
-              :type                     => template_hash[:template_type],
-              :ask_diff_mode_on_launch  => template.ask_diff_mode_on_launch,
-              :ask_variables_on_launch  => template.ask_variables_on_launch,
-              :ask_limit_on_launch      => template.ask_limit_on_launch,
-              :ask_tags_on_launch       => template.ask_tags_on_launch,
-              :ask_skip_tags_on_launch  => template.ask_skip_tags_on_launch,
-              :ask_job_type_on_launch   => template.ask_job_type_on_launch,
-              :ask_verbosity_on_launch  => template.ask_verbosity_on_launch,
-              :ask_inventory_on_launch  => template.ask_inventory_on_launch,
-              :ask_credential_on_launch => template.ask_credential_on_launch,
-              :survey_enabled           => template.survey_enabled,
-            }
+            :extra             => extra
           )
         )
         parse_service_plan(template, template_hash[:survey_spec]) if template_hash[:survey_spec].present?


### PR DESCRIPTION
This is really tricky bug. `WorkflowJobTemplate` doesn't have all the extra attributes like `JobTemplate`. 

But in `AnsibleTowerClient`, the WorkflowJobTemplate is inherited from JobTemplate. 
JobTemplate defines all these methods dynamically at class level, so they are then accessible by WorkflowJobTemplate. 

We haven't discovered this in public tower collecting because collecting of JobTemplates is always preceding to collecting of WorkflowJobTemplates, so methods are defined for both classes. 

In case of asynchronous collecting, the WorkflowJobTemplate can be parsed first and then raises error. 

---

[TPINVTRY-1012](https://projects.engineering.redhat.com/browse/TPINVTRY-1012)