### PR TITLE
Fixed AppliedInventories operation

### DIFF
--- a/lib/topological_inventory/ansible_tower/operations/applied_inventories/tree_item.rb
+++ b/lib/topological_inventory/ansible_tower/operations/applied_inventories/tree_item.rb
@@ -24,7 +24,6 @@ module TopologicalInventory
             parent.add_child(child)
           end
 
-
           def initialize(item)
             self.item     = item
             self.parent   = nil

--- a/spec/helpers/applied_inventories/data.rb
+++ b/spec/helpers/applied_inventories/data.rb
@@ -11,68 +11,68 @@ module AppliedInventories
     def nested_workflows
       {
         'Nested Workflow 1' => {
-          :applied_inventories => [ inventory('1'), inventory('10001'), inventory('3'), inventory('10001'), inventory('10001'), inventory('10001') ].uniq,
-          :prompted_inventory => inventory('0'),
-          :template => workflow('10001', inventory('10001').id),
-          :inventory => inventory('10001'),
-          :child_nodes => [
+          :applied_inventories => [inventory('1'), inventory('10001'), inventory('3'), inventory('10001'), inventory('10001'), inventory('10001')].uniq,
+          :prompted_inventory  => inventory('0'),
+          :template            => workflow('10001', inventory('10001').id),
+          :inventory           => inventory('10001'),
+          :child_nodes         => [
             {
-              :node => node('1101', workflow('10001').id, workflow('1001').id, inventory('1101').id),
+              :node      => node('1101', 'workflow_job', workflow('10001').id, workflow('1001').id, inventory('1101').id),
               :inventory => inventory('1101'),
-              :template => {
-                :template => workflow('1001', nil, true),
-                :inventory => nil,
+              :template  => {
+                :template    => workflow('1001', nil, true),
+                :inventory   => nil,
                 :child_nodes => workflow_child_nodes('1001')
               }
             }
           ]
         },
         'Nested Workflow 2' => {
-          :applied_inventories => [ inventory('1'), nil, inventory('3'), inventory('104'), inventory('5'), inventory('106') ].compact.uniq,
-          :prompted_inventory => nil,
-          :template => workflow('10002'),
-          :inventory => nil,
-          :child_nodes => [
+          :applied_inventories => [inventory('1'), nil, inventory('3'), inventory('104'), inventory('5'), inventory('106')].compact.uniq,
+          :prompted_inventory  => nil,
+          :template            => workflow('10002'),
+          :inventory           => nil,
+          :child_nodes         => [
             {
-              :node => node('1101', workflow('10002').id, '1001', nil),
+              :node      => node('1101', 'workflow_job', workflow('10002').id, '1001', nil),
               :inventory => nil,
-              :template => {
-                :template => workflow('1001', nil, true),
-                :inventory => nil,
+              :template  => {
+                :template    => workflow('1001', nil, true),
+                :inventory   => nil,
                 :child_nodes => workflow_child_nodes('1001')
               }
             }
           ]
         },
         'Nested Workflow 3' => {
-          :applied_inventories => [ inventory('1'), inventory('1101'), inventory('3'), inventory('1101'), inventory('1101'), inventory('1101') ].uniq,
-          :prompted_inventory => inventory('0'),
-          :template => workflow('10003'),
-          :inventory => nil,
-          :child_nodes => [
+          :applied_inventories => [inventory('1'), inventory('1101'), inventory('3'), inventory('1101'), inventory('1101'), inventory('1101')].uniq,
+          :prompted_inventory  => inventory('0'),
+          :template            => workflow('10003'),
+          :inventory           => nil,
+          :child_nodes         => [
             {
-              :node => node('1101', workflow('10003').id, '1001', inventory('1101').id),
+              :node      => node('1101', 'workflow_job', workflow('10003').id, '1001', inventory('1101').id),
               :inventory => inventory('1101'),
-              :template => {
-                :template => workflow('1001', nil, true),
-                :inventory => nil,
+              :template  => {
+                :template    => workflow('1001', nil, true),
+                :inventory   => nil,
                 :child_nodes => workflow_child_nodes('1001')
               }
             }
           ]
         },
         'Nested Workflow 4' => {
-          :applied_inventories => [ inventory('1'), inventory('0'), inventory('3'), inventory('0'), inventory('0'), inventory('0') ].uniq,
-          :prompted_inventory => inventory('0'),
-          :template => workflow('10003', inventory('10003').id, true),
-          :inventory => inventory('10003'),
-          :child_nodes => [
+          :applied_inventories => [inventory('1'), inventory('0'), inventory('3'), inventory('0'), inventory('0'), inventory('0')].uniq,
+          :prompted_inventory  => inventory('0'),
+          :template            => workflow('10003', inventory('10003').id, true),
+          :inventory           => inventory('10003'),
+          :child_nodes         => [
             {
-              :node => node('1101', workflow('10003').id, '1001', inventory('1101').id),
+              :node      => node('1101', 'workflow_job', workflow('10003').id, '1001', inventory('1101').id),
               :inventory => inventory('1101'),
-              :template => {
-                :template => workflow('1001', inventory('1001').id, true),
-                :inventory => inventory('1001'),
+              :template  => {
+                :template    => workflow('1001', inventory('1001').id, true),
+                :inventory   => inventory('1001'),
                 :child_nodes => workflow_child_nodes('1001')
               }
             }
@@ -85,46 +85,46 @@ module AppliedInventories
     def simple_workflows
       {
         'Workflow 1' => {
-          :applied_inventories => [ inventory('1'), nil, inventory('3'), inventory('104'), inventory('5'), inventory('106') ].compact,
-          :prompted_inventory => nil,
-          :template => workflow('1001'),
-          :inventory => nil,
-          :child_nodes => workflow_child_nodes('1001')
+          :applied_inventories => [inventory('1'), nil, inventory('3'), inventory('104'), inventory('5'), inventory('106')].compact,
+          :prompted_inventory  => nil,
+          :template            => workflow('1001'),
+          :inventory           => nil,
+          :child_nodes         => workflow_child_nodes('1001')
         },
         'Workflow 2' => {
-          :applied_inventories => [ inventory('1'), inventory('1002'), inventory('3'), inventory('1002'), inventory('1002'), inventory('1002') ].uniq,
-          :prompted_inventory => nil,
-          :template => workflow('1002', inventory('1002').id),
-          :inventory => inventory('1002'),
-          :child_nodes => workflow_child_nodes('1002')
+          :applied_inventories => [inventory('1'), inventory('1002'), inventory('3'), inventory('1002'), inventory('1002'), inventory('1002')].uniq,
+          :prompted_inventory  => nil,
+          :template            => workflow('1002', inventory('1002').id),
+          :inventory           => inventory('1002'),
+          :child_nodes         => workflow_child_nodes('1002')
         },
         'Workflow 3' => {
-          :applied_inventories => [ inventory('1'), inventory('1003'), inventory('3'), inventory('1003'), inventory('1003'), inventory('1003') ].uniq,
-          :prompted_inventory => inventory('0'),
-          :template => workflow('1003', inventory('1003').id),
-          :inventory => inventory('1003'),
-          :child_nodes => workflow_child_nodes('1003')
+          :applied_inventories => [inventory('1'), inventory('1003'), inventory('3'), inventory('1003'), inventory('1003'), inventory('1003')].uniq,
+          :prompted_inventory  => inventory('0'),
+          :template            => workflow('1003', inventory('1003').id),
+          :inventory           => inventory('1003'),
+          :child_nodes         => workflow_child_nodes('1003')
         },
         'Workflow 4' => {
-          :applied_inventories => [ inventory('1'), inventory('0'), inventory('3'), inventory('0'), inventory('0'), inventory('0') ].uniq,
-          :prompted_inventory => inventory('0'),
-          :template => workflow('1004', inventory('1004').id, true),
-          :inventory => inventory('1004'),
-          :child_nodes => workflow_child_nodes('1004')
+          :applied_inventories => [inventory('1'), inventory('0'), inventory('3'), inventory('0'), inventory('0'), inventory('0')].uniq,
+          :prompted_inventory  => inventory('0'),
+          :template            => workflow('1004', inventory('1004').id, true),
+          :inventory           => inventory('1004'),
+          :child_nodes         => workflow_child_nodes('1004')
         },
         'Workflow 5' => {
-          :applied_inventories => [ inventory('1'), inventory('1005'), inventory('3'), inventory('1005'), inventory('1005'), inventory('1005') ].uniq,
-          :prompted_inventory => nil,
-          :template => workflow('1005', inventory('1005').id, true),
-          :inventory => inventory('1005'),
-          :child_nodes => workflow_child_nodes('1005')
+          :applied_inventories => [inventory('1'), inventory('1005'), inventory('3'), inventory('1005'), inventory('1005'), inventory('1005')].uniq,
+          :prompted_inventory  => nil,
+          :template            => workflow('1005', inventory('1005').id, true),
+          :inventory           => inventory('1005'),
+          :child_nodes         => workflow_child_nodes('1005')
         },
         'Workflow 6' => {
-          :applied_inventories => [ inventory('1'), nil, inventory('3'), inventory('104'), inventory('5'), inventory('106') ].compact,
-          :prompted_inventory => nil,
-          :template => workflow('1006', nil, true),
-          :inventory => nil,
-          :child_nodes => workflow_child_nodes('1006')
+          :applied_inventories => [inventory('1'), nil, inventory('3'), inventory('104'), inventory('5'), inventory('106')].compact,
+          :prompted_inventory  => nil,
+          :template            => workflow('1006', nil, true),
+          :inventory           => nil,
+          :child_nodes         => workflow_child_nodes('1006')
         }
       }
     end
@@ -132,25 +132,25 @@ module AppliedInventories
     def job_templates
       {
         'Job Template 1' => {
-          :applied_inventories => [ inventory('1') ],
-          :template => job_template('1', inventory('1').id),
-          :inventory => inventory('1'),
+          :applied_inventories => [inventory('1')],
+          :template            => job_template('1', inventory('1').id),
+          :inventory           => inventory('1'),
         },
         'Job Template 2' => {
-          :applied_inventories => [ inventory('1') ],
-          :prompted_inventory => inventory('1'),
-          :template => job_template('1', inventory('1').id),
-          :inventory => inventory('1')
+          :applied_inventories => [inventory('1')],
+          :prompted_inventory  => inventory('1'),
+          :template            => job_template('1', inventory('1').id),
+          :inventory           => inventory('1')
         },
         'Job Template 3' => {
           :applied_inventories => [],
-          :prompted_inventory => nil, # This combination isn't possible to launch in Tower
-          :template => job_template('1', nil, true),
+          :prompted_inventory  => nil, # This combination isn't possible to launch in Tower
+          :template            => job_template('1', nil, true),
         },
         'Job Template 4' => {
-          :applied_inventories => [ inventory('1') ],
-          :prompted_inventory => inventory('1'),
-          :template => job_template('1', nil, true)
+          :applied_inventories => [inventory('1')],
+          :prompted_inventory  => inventory('1'),
+          :template            => job_template('1', nil, true)
         },
       }
     end
@@ -158,48 +158,48 @@ module AppliedInventories
     def workflow_child_nodes(root_service_offering_id)
       [
         {
-          :node => node('101', root_service_offering_id, job_template('1').id),
+          :node      => node('101', 'job', root_service_offering_id, job_template('1').id),
           :inventory => nil,
-          :template => {
-            :template => job_template('1', inventory('1').id),
+          :template  => {
+            :template  => job_template('1', inventory('1').id),
             :inventory => inventory('1')
           }
         },
         {
-          :node => node('102', root_service_offering_id, '2'),
+          :node      => node('102', 'job', root_service_offering_id, '2'),
           :inventory => nil,
-          :template => {
+          :template  => {
             :template => job_template('2', nil, true)
           }
         },
         {
-          :node => node('103', root_service_offering_id, '3', inventory('103').id),
+          :node      => node('103', 'job', root_service_offering_id, '3', inventory('103').id),
           :inventory => inventory('103'),
-          :template => {
-            :template => job_template('3', inventory('3').id, false),
+          :template  => {
+            :template  => job_template('3', inventory('3').id, false),
             :inventory => inventory('3')
           }
         },
         {
-          :node => node('104', root_service_offering_id, '4', inventory('104').id),
+          :node      => node('104', 'job', root_service_offering_id, '4', inventory('104').id),
           :inventory => inventory('104'),
-          :template => {
-            :template => job_template('4', inventory('4').id, true),
+          :template  => {
+            :template  => job_template('4', inventory('4').id, true),
             :inventory => inventory('4')
           }
         },
         {
-          :node => node('105', root_service_offering_id, '5'),
+          :node      => node('105', 'job', root_service_offering_id, '5'),
           :inventory => nil,
-          :template => {
-            :template => job_template('5', inventory('5').id, true),
+          :template  => {
+            :template  => job_template('5', inventory('5').id, true),
             :inventory => inventory('5')
           }
         },
         {
-          :node => node('106', root_service_offering_id, '6', inventory('106').id),
+          :node      => node('106', 'job', root_service_offering_id, '6', inventory('106').id),
           :inventory => inventory('106'),
-          :template => {
+          :template  => {
             :template => job_template('6', nil, true)
           }
         }
@@ -222,8 +222,12 @@ module AppliedInventories
                             :prompt_on_launch     => prompt_on_launch)
     end
 
-    def node(id, root_service_offering_id, service_offering_id, service_inventory_id = nil)
-      add_node(:id => id, :service_inventory_id => service_inventory_id, :root_service_offering_id => root_service_offering_id, :service_offering_id => service_offering_id)
+    def node(id, unified_job_type, root_service_offering_id, service_offering_id, service_inventory_id = nil)
+      add_node(:id                       => id,
+               :service_inventory_id     => service_inventory_id,
+               :root_service_offering_id => root_service_offering_id,
+               :service_offering_id      => service_offering_id,
+               :unified_job_type         => unified_job_type)
     end
 
     def inventory(id)
@@ -245,40 +249,41 @@ module AppliedInventories
     private
 
     def add_inventory(id:)
-      TopologicalInventoryApiClient::ServiceInventory.new(:id         => id,
-                                                          :source_id  => source_id,
-                                                          :name       => "Inventory #{id}")
+      TopologicalInventoryApiClient::ServiceInventory.new(:id        => id,
+                                                          :source_id => source_id,
+                                                          :name      => "Inventory #{id}")
     end
 
-    def add_node(id:, service_inventory_id:, service_offering_id:, root_service_offering_id:)
-      TopologicalInventoryApiClient::ServiceOfferingNode.new(:id => id,
-                                                             :name => "Node #{id}",
-                                                             :source_id => source_id,
+    def add_node(id:, service_inventory_id:, service_offering_id:, root_service_offering_id:, unified_job_type:)
+      TopologicalInventoryApiClient::ServiceOfferingNode.new(:id                       => id,
+                                                             :extra                    => {:unified_job_type => unified_job_type},
+                                                             :name                     => "Node #{id}",
+                                                             :source_id                => source_id,
                                                              :root_service_offering_id => root_service_offering_id,
-                                                             :service_offering_id => service_offering_id,
-                                                             :service_inventory_id => service_inventory_id)
+                                                             :service_offering_id      => service_offering_id,
+                                                             :service_inventory_id     => service_inventory_id)
     end
 
     def add_template(id:, service_inventory_id:, prompt_on_launch:, type:)
-      TopologicalInventoryApiClient::ServiceOffering.new(:id => id,
-                                                         :name => "ServiceOffering #{id}",
-                                                         :source_id => source_id,
+      TopologicalInventoryApiClient::ServiceOffering.new(:id                   => id,
+                                                         :name                 => "ServiceOffering #{id}",
+                                                         :source_id            => source_id,
                                                          :service_inventory_id => service_inventory_id,
-                                                         :extra => { :type => type, :ask_inventory_on_launch => prompt_on_launch})
+                                                         :extra                => {:type => type, :ask_inventory_on_launch => prompt_on_launch})
     end
 
     def add_job_template(id:, service_inventory_id:, prompt_on_launch:)
-      add_template(:id => id,
+      add_template(:id                   => id,
                    :service_inventory_id => service_inventory_id,
-                   :prompt_on_launch => prompt_on_launch,
-                   :type => 'job_template')
+                   :prompt_on_launch     => prompt_on_launch,
+                   :type                 => 'job_template')
     end
 
     def add_workflow_template(id:, service_inventory_id:, prompt_on_launch:)
-      add_template(:id => id,
+      add_template(:id                   => id,
                    :service_inventory_id => service_inventory_id,
-                   :prompt_on_launch => prompt_on_launch,
-                   :type => 'workflow_job_template')
+                   :prompt_on_launch     => prompt_on_launch,
+                   :type                 => 'workflow_job_template')
     end
 
     def source_id

--- a/spec/helpers/applied_inventories/data.rb
+++ b/spec/helpers/applied_inventories/data.rb
@@ -4,9 +4,10 @@ module AppliedInventories
     # Hash of samples <Name, Workflow>, each key-pair is one test case
     # Results are in :applied_inventories array
     def templates_and_workflows_data
-      job_templates.merge(simple_workflows).merge(nested_workflows)
+      job_templates.merge(simple_workflows).merge(special_workflows).merge(nested_workflows)
     end
 
+    # :applied_inventories contains the expected result of operation
     # :applied_inventories results are shown for each leaf (job template) in order defined by `workflow_child_nodes`
     def nested_workflows
       {
@@ -125,6 +126,61 @@ module AppliedInventories
           :template            => workflow('1006', nil, true),
           :inventory           => nil,
           :child_nodes         => workflow_child_nodes('1006')
+        }
+      }
+    end
+
+    def special_workflows
+      {
+        'Workflow 7 with inventory_update'                 => {
+          :applied_inventories => [],
+          :prompted_inventory  => nil,
+          :template            => workflow('1007'),
+          :inventory           => nil,
+          :child_nodes         => [
+            {
+              :node      => node('101', 'inventory_update', '1007', nil),
+              :inventory => nil,
+              :template  => {}
+            },
+            {
+              :node      => node('102', 'project_update', '1007', nil),
+              :inventory => nil,
+              :template  => {}
+            }
+          ]
+        },
+        'Workflow 8 with nodes with the same Job Template' => {
+          :applied_inventories => [inventory('1')],
+          :prompted_inventory  => nil,
+          :template            => workflow('1008'),
+          :inventory           => nil,
+          :child_nodes         => [
+            {
+              :node      => node('101', 'job', '1008', job_template('1').id),
+              :inventory => nil,
+              :template  => {
+                :template  => job_template('1', inventory('1').id),
+                :inventory => inventory('1')
+              }
+            },
+            {
+              :node      => node('102', 'job', '1008', job_template('1').id),
+              :inventory => nil,
+              :template  => {
+                :template  => job_template('1', inventory('1').id),
+                :inventory => inventory('1')
+              }
+            },
+            {
+              :node      => node('103', 'job', '1008', job_template('1').id),
+              :inventory => nil,
+              :template  => {
+                :template  => job_template('1', inventory('1').id),
+                :inventory => inventory('1')
+              }
+            }
+          ]
         }
       }
     end

--- a/spec/helpers/applied_inventories/methods.rb
+++ b/spec/helpers/applied_inventories/methods.rb
@@ -32,9 +32,9 @@ module AppliedInventories
       # calls in parser#load_template_inventories
       template_inventories.compact!
       if template_inventories.present?
-        expect(topology_api_client).to receive(:list_service_inventories)
-                                         .with(:filter => {:id => {:eq => match_array(template_inventories.map(&:id))}})
-                                         .and_return(inventory_collection(template_inventories))
+        expect(topology_api_client).to(receive(:list_service_inventories)
+                                         .with(:filter => {:id => {:eq => match_array(template_inventories.map(&:id).uniq)}})
+                                         .and_return(inventory_collection(template_inventories)))
       end
     end
 
@@ -58,14 +58,15 @@ module AppliedInventories
       template_ids, templates, templates_hash = [], [], []
       parent_template[:child_nodes].each do |child_node|
         node_inventories << child_node[:inventory]
+        next if child_node[:template].blank?
 
         templates << child_node[:template][:template]
         templates_hash << child_node[:template]
         template_ids << child_node[:template][:template].id
       end
-      expect(topology_api_client).to receive(:list_service_offerings)
-                                       .with(:filter => {:id => { :eq => match_array(template_ids) }})
-                                       .and_return(template_collection(templates))
+      expect(topology_api_client).to(receive(:list_service_offerings)
+                                       .with(:filter => {:id => {:eq => match_array(template_ids.uniq)}})
+                                       .and_return(template_collection(templates)))
 
       templates_hash.each do |template_hash|
         stub_api_init_template(template_hash, template_inventories, node_inventories)


### PR DESCRIPTION
Skipped inventory_sync and project_sync workflow nodes in building workflow tree

Fixed operation for workflow template with multiple nodes targeting the same job template

**Note**: The ordering will always fail for a short time when this PR will be deployed and until collector re-collects workflow nodes with code in #108 

---

**Depends on**:
* [x] #108 

---

[TPINVTRY-1029](https://projects.engineering.redhat.com/browse/TPINVTRY-1029)
[TPINVTRY-1031](https://projects.engineering.redhat.com/browse/TPINVTRY-1031)