### PR TITLE
Starting receptor worker immediately

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "prometheus_exporter", "~> 0.4.5"
 gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 
-gem "receptor_controller-client", "~> 0.0.2"
+gem "receptor_controller-client", "~> 0.0.6"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"

--- a/lib/topological_inventory/ansible_tower/connection_manager.rb
+++ b/lib/topological_inventory/ansible_tower/connection_manager.rb
@@ -15,21 +15,24 @@ module TopologicalInventory::AnsibleTower
     @sync = Mutex.new
     @receptor_client = nil
 
-    # Receptor client needs to be singleton due to processing of kafka responses
-    def self.receptor_client
-      @sync.synchronize do
-        return @receptor_client if @receptor_client.present?
+    class << self
+      # Receptor client needs to be singleton due to processing of kafka responses
+      def receptor_client
+        @sync.synchronize do
+          return @receptor_client if @receptor_client.present?
 
-        @receptor_client = ReceptorController::Client.new(:logger => TopologicalInventory::AnsibleTower.logger)
-        @receptor_client.start
+          @receptor_client = ReceptorController::Client.new(:logger => TopologicalInventory::AnsibleTower.logger)
+          @receptor_client.start
+        end
+        @receptor_client
       end
-      @receptor_client
-    end
+      alias start_receptor_client receptor_client
 
-    # Stops thread with response worker
-    def self.stop_receptor_client
-      @sync.synchronize do
-        @receptor_client&.stop
+      # Stops thread with response worker
+      def stop_receptor_client
+        @sync.synchronize do
+          @receptor_client&.stop
+        end
       end
     end
 

--- a/lib/topological_inventory/ansible_tower/operations/worker.rb
+++ b/lib/topological_inventory/ansible_tower/operations/worker.rb
@@ -15,6 +15,7 @@ module TopologicalInventory
         end
 
         def run
+          TopologicalInventory::AnsibleTower::ConnectionManager.start_receptor_client
           # Open a connection to the messaging service
           client = ManageIQ::Messaging::Client.open(messaging_client_opts)
 

--- a/lib/topological_inventory/ansible_tower/receptor/collector.rb
+++ b/lib/topological_inventory/ansible_tower/receptor/collector.rb
@@ -14,6 +14,11 @@ module TopologicalInventory::AnsibleTower
         self.tower_hostname = "receptor://#{receptor_node}" # For logging
       end
 
+      def collect!
+        TopologicalInventory::AnsibleTower::ConnectionManager.start_receptor_client
+        super
+      end
+
       def connection_for_entity_type(_entity_type)
         connection_manager.connect(:account_number => account_number,
                                    :receptor_node  => receptor_node)

--- a/spec/operations/worker_spec.rb
+++ b/spec/operations/worker_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::Worker do
     let(:subject) { described_class.new }
     before do
       require "manageiq-messaging"
+      allow(TopologicalInventory::AnsibleTower::ConnectionManager).to receive_messages(:start_receptor_client => nil,
+                                                                                       :stop_receptor_client  => nil)
       allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
       allow(client).to receive(:close)
       allow(subject).to receive(:logger).and_return(double('null_object').as_null_object)


### PR DESCRIPTION
When reading messages from operations worker listener, receptor kafka listener should be initialized. This PR moves start from lazy initialization to the beginning of the process.

Also added the same for receptor controller

---

**Depends on**
- [x] https://github.com/RedHatInsights/receptor_controller-client-ruby/pull/20 
- [x] https://github.com/RedHatInsights/receptor_controller-client-ruby/pull/28