### PR TITLE
Collector: waiting for async responses in main thread

### DIFF
--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -23,7 +23,7 @@ module TopologicalInventory
         until finished?
           ensure_collector_threads
 
-          collector_threads.each_value(&:join)
+          wait_for_collected_data
 
           standalone_mode ? sleep(poll_time) : stop
         end
@@ -32,6 +32,10 @@ module TopologicalInventory
       private
 
       attr_accessor :connection_manager, :metrics, :tower_hostname
+
+      def wait_for_collected_data
+        collector_threads.each_value(&:join)
+      end
 
       def endpoint_types
         %w[service_catalog]

--- a/lib/topological_inventory/ansible_tower/receptor/collector.rb
+++ b/lib/topological_inventory/ansible_tower/receptor/collector.rb
@@ -7,6 +7,8 @@ module TopologicalInventory::AnsibleTower
       def initialize(source, receptor_node, account_number, metrics, standalone_mode: true)
         super(source, metrics, :standalone_mode => standalone_mode)
         self.account_number = account_number # eq Tenant.external_tenant or account_number in x-rh-identity
+        self.entity_types_collected_cnt = Concurrent::AtomicFixnum.new(0)
+        self.last_save_at   = nil
         self.receptor_node  = receptor_node
         self.tower_hostname = "receptor://#{receptor_node}" # For logging
       end
@@ -35,6 +37,7 @@ module TopologicalInventory::AnsibleTower
       end
 
       def async_save_inventory(refresh_state_uuid, parser)
+        self.last_save_at = Time.now.utc
         refresh_state_part_collected_at = Time.now.utc
         refresh_state_part_uuid = SecureRandom.uuid
         save_inventory(parser.collections.values, inventory_name, schema_name, refresh_state_uuid, refresh_state_part_uuid, refresh_state_part_collected_at)
@@ -42,13 +45,40 @@ module TopologicalInventory::AnsibleTower
 
       def async_sweep_inventory(refresh_state_uuid, sweep_scope, total_parts, refresh_state_started_at)
         logger.sweeping(:start, source, sweep_scope, refresh_state_uuid)
+
         sweep_inventory(inventory_name, schema_name, refresh_state_uuid, total_parts, sweep_scope, refresh_state_started_at)
+        entity_types_collected_cnt.increment # Real finish of entity_type's requests
+
         logger.sweeping(:finish, source, sweep_scope, refresh_state_uuid)
       end
 
       private
 
-      attr_accessor :account_number, :receptor_node
+      attr_accessor :account_number, :entity_types_collected_cnt, :last_save_at, :receptor_node
+
+      def start_collector_threads
+        self.last_save_at = nil
+        entity_types_collected_cnt.value = 0
+
+        super
+      end
+
+      def wait_for_collected_data
+        super
+
+        # Wait until all async responses are sent
+        while entity_types_collected_cnt.value < service_catalog_entity_types.size
+          if last_save_at.nil? || (last_save_at < 2.minutes.ago && last_save_at >= 10.minutes.ago)
+            # Either error in collector or big kafka lag from receptor
+            logger.warn("[ASYNC] Collector for source_uid: #{source}: Last response received at #{last_save_at}")
+            sleep(60)
+          elsif last_save_at < 10.minutes.ago
+            break
+          else
+            sleep(1)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When using async responses from receptor, request threads are done very quickly. 
So the main thread should wait until all responses are received