### PR TITLE
Bump providers-common to 1.0.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "receptor_controller-client", "~> 0.0.2"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 1.0.7"
+gem "topological_inventory-providers-common", "~> 1.0.9"
 group :development, :test do
   gem "rspec"
   gem 'rubocop', "~>0.69.0"


### PR DESCRIPTION
**Issue**: https://github.com/RedHatInsights/topological_inventory-persister/issues/66

**Depends on**:
- [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/47