### PR TITLE
Removed collecting of service_instance_nodes

### DIFF
--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -42,7 +42,6 @@ module TopologicalInventory
            service_offerings
            service_instances
            service_offering_nodes
-           service_instance_nodes
            service_credentials
            service_credential_types]
       end


### PR DESCRIPTION
We are collecting ServiceInstanceNodes (Workflow Job Nodes). 
It requires most requests but afaik we don't need this data

So I think we don't need to wait for targeted refresh for removing them. 