### PR TITLE
Logs and sync responses check

### DIFF
--- a/lib/topological_inventory/ansible_tower/receptor/async_receiver.rb
+++ b/lib/topological_inventory/ansible_tower/receptor/async_receiver.rb
@@ -42,6 +42,8 @@ module TopologicalInventory::AnsibleTower
           msg = "[ERROR] Collecting #{entity_type}, :source_uid => #{collector.send(:source)}, :refresh_state_uuid => #{refresh_state_uuid}); MSG ID: #{msg_id}, "
           msg += ":message => #{exception.message}\n#{exception.backtrace.join("\n")}"
           logger.error(msg)
+        ensure
+          collector.response_received!
         end
 
         if entities.present?

--- a/lib/topological_inventory/ansible_tower/receptor/collector.rb
+++ b/lib/topological_inventory/ansible_tower/receptor/collector.rb
@@ -51,6 +51,8 @@ module TopologicalInventory::AnsibleTower
       def async_sweep_inventory(refresh_state_uuid, sweep_scope, total_parts, refresh_state_started_at)
         logger.sweeping(:start, source, sweep_scope, refresh_state_uuid)
 
+        logger.debug("Received #{entity_types_collected_cnt.value} of #{service_catalog_entity_types.size} complete responses")
+
         sweep_inventory(inventory_name, schema_name, refresh_state_uuid, total_parts, sweep_scope, refresh_state_started_at)
         entity_types_collected_cnt.increment # Real finish of entity_type's requests
 
@@ -98,6 +100,8 @@ module TopologicalInventory::AnsibleTower
             break
           end
         end
+
+        logger.info("Total complete entity_types received: #{entity_types_collected_cnt.value} of #{service_catalog_entity_types.size}")
       end
     end
   end

--- a/spec/receptor/async_receiver_spec.rb
+++ b/spec/receptor/async_receiver_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe TopologicalInventory::AnsibleTower::Receptor::AsyncReceiver do
   context "heartbeat" do
     it "informs collector about any received message" do
       allow(collector).to receive_messages(:async_save_inventory => nil, :source => '1234')
-      expect(collector).to receive(:response_received!).exactly(4).times
+      # 4 for each method and 1 for each entity in on_success
+      expect(collector).to receive(:response_received!).exactly(5).times
 
       subject.on_success('1', [service_credential])
       subject.on_error('2', '1', 'Some error')


### PR DESCRIPTION
This PR adds (except logs) update of `last_response_at` after each async parsing of entity to cover synchronous secondary request processing time
