### PR TITLE
Fixed Ordering Issue

### DIFF
--- a/lib/topological_inventory/ansible_tower/receptor/api_object.rb
+++ b/lib/topological_inventory/ansible_tower/receptor/api_object.rb
@@ -29,7 +29,7 @@ module TopologicalInventory::AnsibleTower
       end
 
       def post(data)
-        response = send_request(:post, endpoint, :data => data)
+        response = send_request(:post, endpoint, data)
         raw_kafka_response(response)
       end
 
@@ -82,7 +82,6 @@ module TopologicalInventory::AnsibleTower
 
       def build_payload(http_method, path, params = nil, receptor_opts = {})
         slug = path.to_s
-        slug += "?#{params.to_query}" if params
         payload = {
           'method'          => http_method.to_s.upcase,
           'href_slug'       => slug,

--- a/spec/receptor/api_object_spec.rb
+++ b/spec/receptor/api_object_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe TopologicalInventory::AnsibleTower::Receptor::ApiObject do
                                      .and_return(api_object))
 
         expect(api_object).to(receive(:send_request)
-                                .with(:post, job_order_path, :data => post_data)
+                                .with(:post, job_order_path, post_data)
                                 .and_return('status' => 200, 'body' => body))
 
         response = api.post(job_order_path, post_data)
@@ -192,7 +192,7 @@ RSpec.describe TopologicalInventory::AnsibleTower::Receptor::ApiObject do
 
         payload = {
           'method'          => 'GET',
-          'href_slug'       => '/api/v2/job_templates?id__in=42%2C1',
+          'href_slug'       => '/api/v2/job_templates',
           'params'          => query_params,
           'fetch_all_pages' => true,
           'accept_encoding' => 'gzip'
@@ -202,7 +202,7 @@ RSpec.describe TopologicalInventory::AnsibleTower::Receptor::ApiObject do
                                      .with(account_number,
                                            receptor_node_id,
                                            :directive          => described_class::RECEPTOR_DIRECTIVE,
-                                           :log_message_common => '/api/v2/job_templates?id__in=42%2C1',
+                                           :log_message_common => '/api/v2/job_templates',
                                            :payload            => payload.to_json,
                                            :type               => :non_blocking)
                                      .and_return(directive))


### PR DESCRIPTION
1. There was an extra key called **data** that was being inserted during
ordering which was being rejected by the Ansible Tower.
2. When sending parameters to the receptor plugin you don't have to
put the query parameters in the href_slug you can send it separately.
The appending of the query parameters to the slug has been removed its
redundant.