### PR TITLE
Add HealthCheck operation after message process

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "receptor_controller-client", "~> 0.0.6"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 1.0.9"
+gem "topological_inventory-providers-common", "~> 1.0.10"
 group :development, :test do
   gem "rspec"
   gem 'rubocop', "~>0.69.0"

--- a/lib/topological_inventory/ansible_tower/operations/worker.rb
+++ b/lib/topological_inventory/ansible_tower/operations/worker.rb
@@ -3,6 +3,7 @@ require "topological_inventory/ansible_tower/logging"
 require "topological_inventory/ansible_tower/operations/processor"
 require "topological_inventory/ansible_tower/operations/source"
 require "topological_inventory/ansible_tower/connection_manager"
+require "topological_inventory/providers/common/operations/health_check"
 
 module TopologicalInventory
   module AnsibleTower
@@ -47,6 +48,7 @@ module TopologicalInventory
           raise
         ensure
           message.ack
+          TopologicalInventory::Providers::Common::Operations::HealthCheck.touch_file
         end
 
         def queue_name


### PR DESCRIPTION
https://projects.engineering.redhat.com/browse/TPINVTRY-1055

I am going to add a  to the deployment template that will check if the file has been touched for the last 2 hours, if it has not then OCP will restart the pod for us.

DEPENDS ON:
- [x] [Health Check File Added](https://github.com/RedHatInsights/topological_inventory-providers-common/pull/48)
- [x] [Provider-common gem released](https://github.com/RedHatInsights/topological_inventory-providers-common/pull/49)