### PR TITLE
Add Kafka Heartbeat Thread

### DIFF
--- a/lib/topological_inventory/ansible_tower/operations/worker.rb
+++ b/lib/topological_inventory/ansible_tower/operations/worker.rb
@@ -19,6 +19,7 @@ module TopologicalInventory
           TopologicalInventory::AnsibleTower::ConnectionManager.start_receptor_client
           # Open a connection to the messaging service
           client = ManageIQ::Messaging::Client.open(messaging_client_opts)
+          heartbeat_thread(client)
 
           logger.info("Topological Inventory AnsibleTower Operations worker started...")
           client.subscribe_topic(queue_opts) do |message|
@@ -31,6 +32,7 @@ module TopologicalInventory
         rescue => err
           logger.error("#{err.cause}\n#{err.backtrace.join("\n")}")
         ensure
+          heartbeat_thread.exit
           client&.close
           TopologicalInventory::AnsibleTower::ConnectionManager.stop_receptor_client
         end
@@ -70,6 +72,18 @@ module TopologicalInventory
             :client_ref => "topological-inventory-operations-ansible-tower",
             :group_ref  => "topological-inventory-operations-ansible-tower"
           }
+        end
+
+        # TODO: Probably move this to common eventually, if we need it elsewhere.
+        def heartbeat_thread(client = nil)
+          @heartbeat_thread ||= Thread.new do
+            loop do
+              sleep(15)
+              client.send(:topic_consumer, queue_opts[:persist_ref], nil).trigger_heartbeat!
+            rescue StandardError => e
+              logger.error("Exception in kafka heartbeat thread: #{e.message}, restarting...")
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Adding a heartbeat thread that runs alongside our process_message thread. This should hopefully keep kafka from kicking our consumer out. 


cc @syncrou @slemrmartin

JIRA: https://projects.engineering.redhat.com/browse/TPINVTRY-1060
