### PR TITLE
Revert CloudWatchLogger to 0.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 
 gem "activesupport", '~> 5.2.4.3'
 gem "ansible_tower_client", "~> 0.21.0"
-gem "cloudwatchlogger",   "~> 0.2"
+gem "cloudwatchlogger",   "~> 0.2.1"
 gem "concurrent-ruby"
 gem "manageiq-loggers",   "~> 0.5.0"
 gem "manageiq-messaging", "~> 0.1.2"


### PR DESCRIPTION
CloudWatchLogger in version 0.3.0 now requires new environment variable `AWS_REGION` and is causing https://github.com/zshannon/cloudwatchlogger/issues/16

So reverting back to 0.2.1 until we'll prepare our repo