### PR TITLE
Add response_received! method to AnsibleTower::Collector class

### DIFF
--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -29,6 +29,10 @@ module TopologicalInventory
         end
       end
 
+      # AsyncReceiver method that needs to be on EVERY instance of collector for receptor.
+      def response_received!
+      end
+
       private
 
       attr_accessor :connection_manager, :metrics, :tower_hostname


### PR DESCRIPTION
Getting a NoMethodError on stage currently since the AsyncReceiver calls this method, rather than only call it for collection it is probably just easier to make this 'collector' class just do a no-op for that method.

If there is a better way to do this let me know.
