### PR TITLE
JMESPath filters for on-premise collectors

### DIFF
--- a/lib/topological_inventory/ansible_tower/cloud/collector.rb
+++ b/lib/topological_inventory/ansible_tower/cloud/collector.rb
@@ -26,7 +26,7 @@ module TopologicalInventory::AnsibleTower
         refresh_state_uuid, refresh_state_started_at, refresh_state_part_collected_at = SecureRandom.uuid, Time.now.utc, nil
 
         logger.collecting(:start, source, entity_type, refresh_state_uuid)
-        parser = TopologicalInventory::AnsibleTower::Parser.new(:tower_url => tower_hostname)
+        parser = parser_class.new(:tower_url => tower_hostname)
 
         cnt, sweep_scope, total_parts = 0, Set.new, 0
         # each on ansible_tower_client's enumeration makes pagination requests by itself
@@ -45,7 +45,7 @@ module TopologicalInventory::AnsibleTower
             save_inventory(parser.collections.values, inventory_name, schema_name, refresh_state_uuid, refresh_state_part_uuid, refresh_state_part_collected_at)
             sweep_scope.merge(parser.collections.values.map(&:name))
             # re-init
-            parser = TopologicalInventory::AnsibleTower::Parser.new(:tower_url => tower_hostname)
+            parser = parser_class.new(:tower_url => tower_hostname)
             cnt    = 0
           end
         end

--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -67,6 +67,10 @@ module TopologicalInventory
            service_credential_types]
       end
 
+      def parser_class
+        TopologicalInventory::AnsibleTower::Parser
+      end
+
       def inventory_name
         "AnsibleTower"
       end

--- a/lib/topological_inventory/ansible_tower/parser.rb
+++ b/lib/topological_inventory/ansible_tower/parser.rb
@@ -32,6 +32,17 @@ module TopologicalInventory::AnsibleTower
       props
     end
 
+    # Filtering of fields by JMESPath language (implemented by receptor_catalog plugin)
+    # Option 'apply_filter' of collector's receptor_params
+    def self.receptor_filter_list(fields:, related: nil, summary_fields: nil)
+      filter = []
+      filter << fields.collect { |col| "#{col}:#{col}" }.join(',') if fields
+      filter << "related:{#{related.collect { |col| "#{col}:related.#{col}" }.join(',')}}" if related
+      filter << "summary_fields:{#{summary_fields.collect { |col| "#{col}:summary_fields.#{col}" }.join(',')}}" if summary_fields
+
+      {:results => "results[].{#{filter.join(',')}}"}
+    end
+
     protected
 
     attr_accessor :tower_url

--- a/lib/topological_inventory/ansible_tower/parser.rb
+++ b/lib/topological_inventory/ansible_tower/parser.rb
@@ -36,9 +36,9 @@ module TopologicalInventory::AnsibleTower
     # Option 'apply_filter' of collector's receptor_params
     def self.receptor_filter_list(fields:, related: nil, summary_fields: nil)
       filter = []
-      filter << fields.collect { |col| "#{col}:#{col}" }.join(',') if fields
-      filter << "related:{#{related.collect { |col| "#{col}:related.#{col}" }.join(',')}}" if related
-      filter << "summary_fields:{#{summary_fields.collect { |col| "#{col}:summary_fields.#{col}" }.join(',')}}" if summary_fields
+      filter << fields.collect { |col| "#{col}:#{col}" }.join(',') if fields.present?
+      filter << "related:{#{related.collect { |col| "#{col}:related.#{col}" }.join(',')}}" if related.present?
+      filter << "summary_fields:{#{summary_fields.collect { |col| "#{col}:summary_fields.#{col}" }.join(',')}}" if summary_fields.present?
 
       {:results => "results[].{#{filter.join(',')}}"}
     end

--- a/lib/topological_inventory/ansible_tower/parser/service_credential.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_credential.rb
@@ -13,6 +13,20 @@ module TopologicalInventory::AnsibleTower
           )
         )
       end
+
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def receptor_filter_service_credentials
+          receptor_filter_list(:fields  => %i[id
+                                              created
+                                              credential_type
+                                              description name],
+                               :related => %i[credential_type])
+        end
+      end
     end
   end
 end

--- a/lib/topological_inventory/ansible_tower/parser/service_credential_type.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_credential_type.rb
@@ -4,13 +4,28 @@ module TopologicalInventory::AnsibleTower
       def parse_service_credential_type(credential_type)
         collections.service_credential_types.build(
           parse_base_item(credential_type).merge(
-            :source_ref        => credential_type.id.to_s,
-            :name              => credential_type.name.to_s,
-            :description       => credential_type.description.to_s,
-            :kind              => credential_type.kind.to_s,
-            :namespace         => credential_type.namespace.to_s,
+            :source_ref  => credential_type.id.to_s,
+            :name        => credential_type.name.to_s,
+            :description => credential_type.description.to_s,
+            :kind        => credential_type.kind.to_s,
+            :namespace   => credential_type.namespace.to_s
           )
         )
+      end
+
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def receptor_filter_service_credential_types
+          receptor_filter_list(:fields => %i[id
+                                             created
+                                             description
+                                             kind
+                                             name
+                                             namespace])
+        end
       end
     end
   end

--- a/lib/topological_inventory/ansible_tower/parser/service_instance.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_instance.rb
@@ -28,8 +28,8 @@ module TopologicalInventory::AnsibleTower
 
         collections.service_instances.build(
           parse_base_item(job).merge(
-            :source_ref       => job.id.to_s,
-            :service_offering => lazy_find(:service_offerings, :source_ref => job.unified_job_template_id.to_s),
+            :source_ref            => job.id.to_s,
+            :service_offering      => lazy_find(:service_offerings, :source_ref => job.unified_job_template_id.to_s),
             # it creates skeletal service_plans because not all jobs have corresponding survey
             :service_plan          => lazy_find(:service_plans, :source_ref => job.unified_job_template_id.to_s),
             :service_inventory     => service_inventory,
@@ -42,10 +42,32 @@ module TopologicalInventory::AnsibleTower
         if job.summary_fields && job_hash[:job_type] == :job
           job.summary_fields.credentials.each do |credential|
             collections.service_instance_service_credentials.build(
-                :service_instance   => lazy_find(:service_instances, :source_ref => job.id.to_s),
-                :service_credential => lazy_find(:service_credentials, :source_ref => credential.id.to_s)
+              :service_instance   => lazy_find(:service_instances, :source_ref => job.id.to_s),
+              :service_credential => lazy_find(:service_credentials, :source_ref => credential.id.to_s)
             )
           end
+        end
+      end
+
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def receptor_filter_service_instances
+          receptor_filter_list(:fields         => %i[id
+                                                     artifacts
+                                                     created
+                                                     extra_vars
+                                                     finished
+                                                     inventory
+                                                     started
+                                                     status
+                                                     unified_job_template],
+                               :related        => %i[inventory
+                                                     unified_job_template],
+                               :summary_fields => %i[credentials
+                                                     source_workflow_job])
         end
       end
     end

--- a/lib/topological_inventory/ansible_tower/parser/service_instance.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_instance.rb
@@ -63,6 +63,7 @@ module TopologicalInventory::AnsibleTower
                                                      inventory
                                                      started
                                                      status
+                                                     type
                                                      unified_job_template],
                                :related        => %i[inventory
                                                      unified_job_template],

--- a/lib/topological_inventory/ansible_tower/parser/service_instance_node.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_instance_node.rb
@@ -46,6 +46,7 @@ module TopologicalInventory::AnsibleTower
 
       module ClassMethods
         def receptor_filter_service_instance_nodes
+          # related[:credentials] are used in get_service_instance_nodes as a subrequest
           receptor_filter_list(:fields         => %i[id
                                                      always_nodes
                                                      created
@@ -59,6 +60,7 @@ module TopologicalInventory::AnsibleTower
                                                      skip_tags
                                                      success_nodes],
                                :related        => %i[always_nodes
+                                                     credentials
                                                      failure_nodes
                                                      inventory
                                                      success_nodes],

--- a/lib/topological_inventory/ansible_tower/parser/service_instance_node.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_instance_node.rb
@@ -39,6 +39,33 @@ module TopologicalInventory::AnsibleTower
           )
         end
       end
+
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def receptor_filter_service_instance_nodes
+          receptor_filter_list(:fields         => %i[id
+                                                     always_nodes
+                                                     created
+                                                     failure_nodes
+                                                     job_tags
+                                                     job_type
+                                                     limit
+                                                     modified
+                                                     name
+                                                     inventory
+                                                     skip_tags
+                                                     success_nodes],
+                               :related        => %i[always_nodes
+                                                     failure_nodes
+                                                     inventory
+                                                     success_nodes],
+                               :summary_fields => %i[job
+                                                     workflow_job])
+        end
+      end
     end
   end
 end

--- a/lib/topological_inventory/ansible_tower/parser/service_inventory.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_inventory.rb
@@ -20,6 +20,29 @@ module TopologicalInventory::AnsibleTower
           )
         )
       end
+
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def receptor_filter_service_inventories
+          receptor_filter_list(:fields  => %i[id
+                                              created
+                                              description
+                                              host_filter
+                                              inventory_sources_with_failures
+                                              kind
+                                              modified
+                                              name
+                                              organization
+                                              pending_deletion
+                                              total_inventory_sources
+                                              type
+                                              variables],
+                               :related => %i[organization])
+        end
+      end
     end
   end
 end

--- a/lib/topological_inventory/ansible_tower/parser/service_offering.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_offering.rb
@@ -8,7 +8,6 @@ module TopologicalInventory::AnsibleTower
 
         extra = {
           :type                    => template_hash[:template_type],
-          :ask_variables_on_launch => template.ask_variables_on_launch,
           :ask_inventory_on_launch => template.ask_inventory_on_launch,
           :survey_enabled          => template.survey_enabled,
         }
@@ -16,12 +15,6 @@ module TopologicalInventory::AnsibleTower
         if template_hash[:template_type].to_s == 'job_template'
           extra = extra.merge(
             :ask_credential_on_launch => template.ask_credential_on_launch,
-            :ask_diff_mode_on_launch  => template.ask_diff_mode_on_launch,
-            :ask_job_type_on_launch   => template.ask_job_type_on_launch,
-            :ask_limit_on_launch      => template.ask_limit_on_launch,
-            :ask_skip_tags_on_launch  => template.ask_skip_tags_on_launch,
-            :ask_tags_on_launch       => template.ask_tags_on_launch,
-            :ask_verbosity_on_launch  => template.ask_verbosity_on_launch
           )
         end
 
@@ -46,6 +39,26 @@ module TopologicalInventory::AnsibleTower
         end
 
         service_offering
+      end
+
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def receptor_filter_service_offerings
+          receptor_filter_list(:fields         => %i[id
+                                                     ask_credential_on_launch
+                                                     ask_inventory_on_launch
+                                                     created
+                                                     description
+                                                     name
+                                                     inventory
+                                                     survey_enabled
+                                                     type],
+                               :related        => %i[inventory],
+                               :summary_fields => %i[credentials])
+        end
       end
     end
   end

--- a/lib/topological_inventory/ansible_tower/parser/service_offering.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_offering.rb
@@ -7,7 +7,7 @@ module TopologicalInventory::AnsibleTower
         service_inventory = lazy_find(:service_inventories, :source_ref => template.inventory_id.to_s) if template.respond_to?(:inventory_id)
 
         extra = {
-          :type                    => template_hash[:template_type],
+          :type                    => template.type.to_sym,
           :ask_inventory_on_launch => template.ask_inventory_on_launch,
           :survey_enabled          => template.survey_enabled,
         }

--- a/lib/topological_inventory/ansible_tower/parser/service_offering_node.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_offering_node.rb
@@ -37,9 +37,36 @@ module TopologicalInventory::AnsibleTower
 
         offering_node[:credentials].to_a.each do |credential|
           collections.service_offering_node_service_credentials.build(
-              :service_offering_node => lazy_find(:service_offering_nodes, :source_ref => node.id.to_s),
-              :service_credential    => lazy_find(:service_credentials, :source_ref => credential.id.to_s)
+            :service_offering_node => lazy_find(:service_offering_nodes, :source_ref => node.id.to_s),
+            :service_credential    => lazy_find(:service_credentials, :source_ref => credential.id.to_s)
           )
+        end
+      end
+
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def receptor_filter_service_offering_nodes
+          receptor_filter_list(:fields         => %i[id
+                                                     always_nodes
+                                                     created
+                                                     failure_nodes
+                                                     job_tags
+                                                     job_type
+                                                     limit
+                                                     modified
+                                                     name
+                                                     inventory
+                                                     skip_tags
+                                                     success_nodes],
+                               :related        => %i[always_nodes
+                                                     failure_nodes
+                                                     inventory
+                                                     success_nodes],
+                               :summary_fields => %i[unified_job_template
+                                                     workflow_job_template])
         end
       end
     end

--- a/lib/topological_inventory/ansible_tower/parser/service_offering_node.rb
+++ b/lib/topological_inventory/ansible_tower/parser/service_offering_node.rb
@@ -49,6 +49,7 @@ module TopologicalInventory::AnsibleTower
 
       module ClassMethods
         def receptor_filter_service_offering_nodes
+          # related[:credentials] are used in get_service_offering_nodes as a subrequest
           receptor_filter_list(:fields         => %i[id
                                                      always_nodes
                                                      created
@@ -62,6 +63,7 @@ module TopologicalInventory::AnsibleTower
                                                      skip_tags
                                                      success_nodes],
                                :related        => %i[always_nodes
+                                                     credentials
                                                      failure_nodes
                                                      inventory
                                                      success_nodes],

--- a/lib/topological_inventory/ansible_tower/receptor/async_receiver.rb
+++ b/lib/topological_inventory/ansible_tower/receptor/async_receiver.rb
@@ -35,7 +35,7 @@ module TopologicalInventory::AnsibleTower
           # Exceptions can be raised by synchronous requests inside transformation
           parsable_entity = transformation ? transformation.call(entity) : entity
           parser.send("parse_#{entity_type.singularize}", parsable_entity)
-        rescue ReceptorController::Client::Error => exception
+        rescue => exception
           # Archiving when error occurred isn't wanted, skipping sweep
           sweeping_enabled.value = false
 

--- a/lib/topological_inventory/ansible_tower/receptor/collector.rb
+++ b/lib/topological_inventory/ansible_tower/receptor/collector.rb
@@ -37,10 +37,12 @@ module TopologicalInventory::AnsibleTower
                                      refresh_state_started_at,
                                      :sweeping_enabled => !sweeping_disabled)
 
-        # opts = {:fetch_all_pages => true, :accept_encoding => 'gzip', :apply_filter => nil}
         receptor_params = {:accept_encoding => 'gzip', :fetch_all_pages => true}
-        query_params    = {:page_size => limits[entity_type]}
+        receptor_params[:apply_filter] = parser_class.send("receptor_filter_#{entity_type}")
+
+        query_params = {:page_size => limits[entity_type]}
         query_params[:modified__gt] = last_modified_at if scheduler.do_partial_refresh?(source)
+
         send("get_#{entity_type}", connection, query_params,
              :on_premise => true, :receptor_receiver => receiver, :receptor_params => receptor_params)
       end

--- a/lib/topological_inventory/ansible_tower/targeted_refresh/service_instance.rb
+++ b/lib/topological_inventory/ansible_tower/targeted_refresh/service_instance.rb
@@ -117,6 +117,7 @@ module TopologicalInventory
         def refresh_part_on_premise(_tasks_id, query_params)
           refresh_state_started_at = Time.now.utc
           receptor_params = {:accept_encoding => 'gzip', :fetch_all_pages => true}
+          receptor_params[:apply_filter] = parser_class.receptor_filter_service_instances
 
           receiver = TopologicalInventory::AnsibleTower::Receptor::AsyncReceiver.new(self, connection,
                                                                                      'service_instances',

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,0 +1,93 @@
+RSpec.describe TopologicalInventory::AnsibleTower::Parser do
+  describe '#receptor_filter_list' do
+    it "creates JMESPath filter from 'fields' arg" do
+      filter = described_class.receptor_filter_list(:fields => %i[f1 f2 f3])
+      expect(filter).to eq(:results => 'results[].{f1:f1,f2:f2,f3:f3}')
+    end
+
+    it "creates JMESPath filter from 'related' arg" do
+      filter = described_class.receptor_filter_list(:fields => [], :related => %i[r1 r2 r3])
+      expect(filter).to eq(:results => 'results[].{related:{r1:related.r1,r2:related.r2,r3:related.r3}}')
+    end
+
+    it "creates JMESPath filter from 'summary_field' arg" do
+      filter = described_class.receptor_filter_list(:fields => nil, :summary_fields => %i[s1 s2])
+      expect(filter).to eq(:results => 'results[].{summary_fields:{s1:summary_fields.s1,s2:summary_fields.s2}}')
+    end
+
+    it "creates JMESPath filter from all args" do
+      filter = described_class.receptor_filter_list(:fields         => %i[f1 f2],
+                                                    :related        => %i[r1 r2],
+                                                    :summary_fields => %i[s1])
+      expect(filter).to eq(:results => 'results[].{f1:f1,f2:f2,related:{r1:related.r1,r2:related.r2},summary_fields:{s1:summary_fields.s1}}')
+    end
+  end
+
+  %w[service_credential
+     service_credential_type
+     service_instance
+     service_instance_node
+     service_inventory
+     service_offering
+     service_offering_node].each do |entity_type|
+    describe "#receptor_filter_#{entity_type.pluralize}" do
+      let(:data) { double(entity_type) }
+      let(:summary_fields) { double("Summary Fields object") }
+
+      subject { described_class.new(:tower_url => 'tower.example.com') }
+
+      before do
+        allow(data).to receive(:summary_fields).and_return(summary_fields)
+
+        allow(described_class).to receive(:receptor_filter_list) do |args|
+          args[:fields].each do |field|
+            if args[:related].to_a.include?(field)
+              #
+              # All fields in 'related' are called as <field>_id (AnsibleTowerClient transformation)
+              #
+              expect(data).to receive("#{field}_id".to_sym).at_least(:once).and_return(42)
+            else
+              method_name = field == :extra_vars ? :extra_vars_hash : field # Job specific
+              return_value = case field
+                             when :type
+                               case entity_type
+                               when 'service_instance' then 'job'
+                               when 'service_offering' then 'job_template'
+                               end
+                             else field.to_s
+                             end
+              expect(data).to receive(method_name.to_sym).at_least(:once).and_return(return_value)
+            end
+          end
+
+          args[:summary_fields].to_a.each do |summary_field|
+            returned_object = if summary_field == :credentials
+                                []
+                              else
+                                double("summary_field #{summary_field}").as_null_object
+                              end
+            expect(summary_fields).to receive(summary_field).at_least(:once).and_return(returned_object)
+          end
+        end
+
+        described_class.send("receptor_filter_#{entity_type.pluralize}")
+      end
+
+      it "covers all fields from parse_#{entity_type}" do
+        input_arg = case entity_type
+                    when 'service_instance'
+                      {:job => data, :job_type => :job}
+                    when 'service_instance_node'
+                      {:node => data, :credentials => nil}
+                    when 'service_offering'
+                      {:template => data, :template_type => :job_template, :survey_spec => nil}
+                    when 'service_offering_node'
+                      {:node => data, :credentials => nil}
+                    else
+                      data
+                    end
+        subject.send("parse_#{entity_type}", input_arg)
+      end
+    end
+  end
+end

--- a/spec/receptor/collector_spec.rb
+++ b/spec/receptor/collector_spec.rb
@@ -40,12 +40,13 @@ RSpec.describe TopologicalInventory::AnsibleTower::Receptor::Collector do
       it "invokes on-premise requests" do
         expect(TopologicalInventory::AnsibleTower::Receptor::AsyncReceiver).to receive(:new).and_return(receiver)
 
+        apply_filter = {:results => "results[].{id:id,ask_credential_on_launch:ask_credential_on_launch,ask_inventory_on_launch:ask_inventory_on_launch,created:created,description:description,name:name,inventory:inventory,survey_enabled:survey_enabled,type:type,related:{inventory:related.inventory},summary_fields:{credentials:summary_fields.credentials}}"}
         expect(subject).to(receive(:get_service_offerings)
                              .with(connection,
                                    {:page_size => subject.send(:limits)[entity_type]},
                                    {:on_premise        => true,
                                     :receptor_receiver => receiver,
-                                    :receptor_params   => {:accept_encoding => 'gzip', :fetch_all_pages => true}}))
+                                    :receptor_params   => {:accept_encoding => 'gzip', :apply_filter => apply_filter, :fetch_all_pages => true}}))
 
         subject.collector_thread(connection, entity_type)
       end

--- a/spec/receptor/collector_spec.rb
+++ b/spec/receptor/collector_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe TopologicalInventory::AnsibleTower::Receptor::Collector do
     let(:connection) { double('Connection') }
     let(:entity_type) { 'service_offerings' }
     let(:receiver) { double('Async receiver') }
+    let(:service_offerings_apply_filter) { {:results => "results[].{id:id,ask_credential_on_launch:ask_credential_on_launch,ask_inventory_on_launch:ask_inventory_on_launch,created:created,description:description,name:name,inventory:inventory,survey_enabled:survey_enabled,type:type,related:{inventory:related.inventory},summary_fields:{credentials:summary_fields.credentials}}"} }
 
     context "running full-refresh" do
       before do
@@ -40,13 +41,12 @@ RSpec.describe TopologicalInventory::AnsibleTower::Receptor::Collector do
       it "invokes on-premise requests" do
         expect(TopologicalInventory::AnsibleTower::Receptor::AsyncReceiver).to receive(:new).and_return(receiver)
 
-        apply_filter = {:results => "results[].{id:id,ask_credential_on_launch:ask_credential_on_launch,ask_inventory_on_launch:ask_inventory_on_launch,created:created,description:description,name:name,inventory:inventory,survey_enabled:survey_enabled,type:type,related:{inventory:related.inventory},summary_fields:{credentials:summary_fields.credentials}}"}
         expect(subject).to(receive(:get_service_offerings)
                              .with(connection,
                                    {:page_size => subject.send(:limits)[entity_type]},
                                    {:on_premise        => true,
                                     :receptor_receiver => receiver,
-                                    :receptor_params   => {:accept_encoding => 'gzip', :apply_filter => apply_filter, :fetch_all_pages => true}}))
+                                    :receptor_params   => {:accept_encoding => 'gzip', :apply_filter => service_offerings_apply_filter, :fetch_all_pages => true}}))
 
         subject.collector_thread(connection, entity_type)
       end
@@ -82,7 +82,7 @@ RSpec.describe TopologicalInventory::AnsibleTower::Receptor::Collector do
                                     :modified__gt => @start_time.iso8601},
                                    {:on_premise        => true,
                                     :receptor_receiver => receiver,
-                                    :receptor_params   => {:accept_encoding => 'gzip', :fetch_all_pages => true}}))
+                                    :receptor_params   => {:accept_encoding => 'gzip', :apply_filter => service_offerings_apply_filter, :fetch_all_pages => true}}))
 
         subject.collector_thread(connection, entity_type)
       end


### PR DESCRIPTION
JMESPath filters can reduce size of collected data from on-premise towers. It's implemented in receptor_catalog plugin as `apply_filter` option (see [receptor_catalog's README](https://github.com/mkanoor/receptor-catalog/blob/master/README.md) )

---

[RHCLOUD-9236](https://issues.redhat.com/browse/RHCLOUD-9236)