### PR TITLE
Partial refresh (API calls with timestamp)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,5 +26,6 @@ group :development, :test do
   gem "rubocop-performance", "~> 1.8"
   gem "rubocop-rails", "~> 2.8"
   gem "simplecov", "~> 0.17.1"
+  gem "timecop", "~> 0.9.1"
   gem "webmock"
 end

--- a/bin/ansible_tower-collector
+++ b/bin/ansible_tower-collector
@@ -83,8 +83,8 @@ ReceptorController::Client.configure do |config|
 end
 
 TopologicalInventory::AnsibleTower::Collector::Scheduler.configure do |config|
-  config.full_refresh_frequency = ENV['COLLECTOR_FULL_REFRESH_FREQUENCY'] || 3600
-  config.partial_refresh_frequency = ENV['COLLECTOR_PARTIAL_REFRESH_FREQUENCY'] || ENV['COLLECTOR_POLL_TIME'] || 300
+  config.full_refresh_frequency = (ENV['COLLECTOR_FULL_REFRESH_FREQUENCY'] || 3600).to_i
+  config.partial_refresh_frequency = (ENV['COLLECTOR_PARTIAL_REFRESH_FREQUENCY'] || ENV['COLLECTOR_POLL_TIME'] || 300).to_i
 end
 
 

--- a/bin/ansible_tower-collector
+++ b/bin/ansible_tower-collector
@@ -9,6 +9,7 @@ require "bundler/setup"
 require "topological_inventory/ansible_tower/cloud/collector"
 require "topological_inventory/ansible_tower/receptor/collector"
 require "topological_inventory/ansible_tower/collectors_pool"
+require "topological_inventory/ansible_tower/collector/scheduler"
 require "topological_inventory/ansible_tower/collector/application_metrics"
 
 def parse_args
@@ -81,6 +82,11 @@ ReceptorController::Client.configure do |config|
   config.pre_shared_key    = args[:receptor_controller_psk]
 end
 
+TopologicalInventory::AnsibleTower::Collector::Scheduler.configure do |config|
+  config.full_refresh_frequency = ENV['COLLECTOR_FULL_REFRESH_FREQUENCY'] || 3600
+  config.partial_refresh_frequency = ENV['COLLECTOR_PARTIAL_REFRESH_FREQUENCY'] || ENV['COLLECTOR_POLL_TIME'] || 300
+end
+
 
 metrics = TopologicalInventory::AnsibleTower::Collector::ApplicationMetrics.new(args[:metrics_port])
 if args[:config].nil?
@@ -97,6 +103,9 @@ if args[:config].nil?
                                                                             metrics,
                                                                             :default_limit => args[:page_size])
               end
+
+  scheduler = TopologicalInventory::AnsibleTower::Collector::Scheduler.default
+  scheduler.add_source(args[:source])
 
   collector.collect!
 else

--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -88,7 +88,7 @@ module TopologicalInventory
       end
 
       def refresh_finished(refresh_type)
-        msg = "Refresh finished | :type => #{refresh_type.to_s}"
+        msg = "Refresh finished | :type => #{refresh_type}"
         if refresh_type == :partial_refresh
           scheduler.partial_refresh_finished!(source)
         else

--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -1,3 +1,4 @@
+require 'time'
 require "topological_inventory/ansible_tower/logging"
 require "topological_inventory/providers/common/collector"
 require "topological_inventory/ansible_tower/connection_manager"
@@ -12,7 +13,10 @@ module TopologicalInventory
       require "topological_inventory/ansible_tower/collector/service_catalog"
       include TopologicalInventory::AnsibleTower::Collector::ServiceCatalog
 
-      def initialize(source, metrics, default_limit: 100, poll_time: 60, standalone_mode: true)
+      def initialize(source, metrics,
+                     default_limit: 100,
+                     poll_time: scheduler.partial_refresh_frequency,
+                     standalone_mode: true)
         super(source, :default_limit => default_limit, :poll_time => poll_time, :standalone_mode => standalone_mode)
         self.connection_manager = TopologicalInventory::AnsibleTower::ConnectionManager.new(source)
         self.metrics            = metrics
@@ -21,9 +25,14 @@ module TopologicalInventory
 
       def collect!
         until finished?
-          ensure_collector_threads
+          if scheduler.do_refresh?(source)
+            refresh_type = refresh_started
 
-          wait_for_collected_data
+            ensure_collector_threads
+            wait_for_collected_data
+
+            refresh_finished(refresh_type)
+          end
 
           standalone_mode ? sleep(poll_time) : stop
         end
@@ -36,6 +45,11 @@ module TopologicalInventory
       private
 
       attr_accessor :connection_manager, :metrics, :tower_hostname
+
+      def scheduler
+        require "topological_inventory/ansible_tower/collector/scheduler"
+        TopologicalInventory::AnsibleTower::Collector::Scheduler.default
+      end
 
       def wait_for_collected_data
         collector_threads.each_value(&:join)
@@ -55,6 +69,39 @@ module TopologicalInventory
 
       def inventory_name
         "AnsibleTower"
+      end
+
+      def refresh_started
+        msg          = "Refresh started | :type => "
+        refresh_type = if scheduler.do_partial_refresh?(source)
+                         scheduler.partial_refresh_started!(source)
+                         msg += ":partial_refresh, :from => #{last_modified_at}"
+                         :partial_refresh
+                       else
+                         scheduler.full_refresh_started!(source)
+                         msg += ':full_refresh'
+                         :full_refresh
+                       end
+        logger.info("#{msg}, :source_uid => #{source}")
+
+        refresh_type
+      end
+
+      def refresh_finished(refresh_type)
+        msg = "Refresh finished | :type => #{refresh_type.to_s}"
+        if refresh_type == :partial_refresh
+          scheduler.partial_refresh_finished!(source)
+        else
+          scheduler.full_refresh_finished!(source)
+        end
+        logger.info("#{msg}, :source_uid => #{source}")
+      end
+
+      # Last time of partial refresh, used in API calls
+      def last_modified_at
+        if scheduler.do_partial_refresh?(source)
+          scheduler.last_partial_refresh_at(source)&.iso8601
+        end
       end
     end
   end

--- a/lib/topological_inventory/ansible_tower/collector.rb
+++ b/lib/topological_inventory/ansible_tower/collector.rb
@@ -95,6 +95,9 @@ module TopologicalInventory
           scheduler.full_refresh_finished!(source)
         end
         logger.info("#{msg}, :source_uid => #{source}")
+      rescue => e
+        logger.error("#{msg} | #{e.message}\n#{e.backtrace.join('\n')}")
+        metrics&.record_error
       end
 
       # Last time of partial refresh, used in API calls

--- a/lib/topological_inventory/ansible_tower/collector/scheduler.rb
+++ b/lib/topological_inventory/ansible_tower/collector/scheduler.rb
@@ -1,0 +1,100 @@
+require 'concurrent'
+
+module TopologicalInventory
+  module AnsibleTower
+    class Collector
+      class Scheduler
+        attr_accessor :full_refresh_frequency,
+                      :partial_refresh_frequency
+
+        def self.default
+          @default ||= new
+        end
+
+        def self.configure
+          if block_given?
+            yield(default)
+          else
+            default
+          end
+        end
+
+        def initialize
+          self.full_refresh_frequency    = ENV['COLLECTOR_FULL_REFRESH_FREQUENCY'] || 120
+          self.timestamps                = Concurrent::Map.new
+          self.partial_refresh_frequency = ENV['COLLECTOR_PARTIAL_REFRESH_FREQUENCY'] || 60
+        end
+
+        def add_source(source_uid)
+          timestamps[source_uid] = {:full_refresh => {}, :partial_refresh => {}}
+        end
+
+        def remove_source(source_uid)
+          timestamps.delete(source_uid)
+        end
+
+        def do_refresh?(source_uid)
+          do_full_refresh?(source_uid) || do_partial_refresh?(source_uid)
+        end
+
+        def do_full_refresh?(source_uid)
+          return true if timestamps[source_uid].try(:[], :full_refresh).nil?
+
+          timestamps[source_uid][:full_refresh][:last_finished_at].nil? ||
+            timestamps[source_uid][:full_refresh][:last_finished_at] < full_refresh_frequency.seconds.ago.utc
+        end
+
+        def do_partial_refresh?(source_uid)
+          return false if do_full_refresh?(source_uid)
+
+          timestamps[source_uid][:partial_refresh][:last_finished_at].nil? ||
+            timestamps[source_uid][:partial_refresh][:last_finished_at] < partial_refresh_frequency.seconds.ago.utc
+        end
+
+        def full_refresh_started!(source_uid)
+          refresh_started(:full_refresh, source_uid)
+        end
+
+        def full_refresh_finished!(source_uid)
+          refresh_finished(:full_refresh, source_uid)
+          refresh_finished(:partial_refresh, source_uid)
+        end
+
+        def partial_refresh_started!(source_uid)
+          refresh_started(:partial_refresh, source_uid)
+        end
+
+        def partial_refresh_finished!(source_uid)
+          refresh_finished(:partial_refresh, source_uid)
+        end
+
+        def last_partial_refresh_at(source_uid)
+          return nil unless timestamps[source_uid]
+
+          timestamps[source_uid][:partial_refresh][:last_finished_at]
+        end
+
+        private
+
+        attr_accessor :timestamps
+
+        def refresh_started(type, source_uid)
+          add_source(source_uid) unless timestamps[source_uid]
+
+          timestamps[source_uid][type][:started_at] = Time.now.utc
+        end
+
+        def refresh_finished(type, source_uid)
+          started_at = timestamps[source_uid].try(:[], type).try(:[], :started_at)
+          if started_at.nil? && type == :partial_refresh
+            started_at = timestamps[source_uid].try(:[], :full_refresh).try(:[], :started_at)
+          end
+
+          raise "Refresh started_at for source #{source_uid} is missing!" if started_at.nil?
+
+          timestamps[source_uid][type][:last_finished_at] = started_at
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/ansible_tower/collector/scheduler.rb
+++ b/lib/topological_inventory/ansible_tower/collector/scheduler.rb
@@ -20,9 +20,9 @@ module TopologicalInventory
         end
 
         def initialize
-          self.full_refresh_frequency    = ENV['COLLECTOR_FULL_REFRESH_FREQUENCY'] || 120
+          self.full_refresh_frequency    = (ENV['COLLECTOR_FULL_REFRESH_FREQUENCY'] || 3600).to_i
           self.timestamps                = Concurrent::Map.new
-          self.partial_refresh_frequency = ENV['COLLECTOR_PARTIAL_REFRESH_FREQUENCY'] || 60
+          self.partial_refresh_frequency = (ENV['COLLECTOR_PARTIAL_REFRESH_FREQUENCY'] || 300).to_i
         end
 
         def add_source(source_uid)

--- a/lib/topological_inventory/ansible_tower/receptor/collector.rb
+++ b/lib/topological_inventory/ansible_tower/receptor/collector.rb
@@ -34,6 +34,7 @@ module TopologicalInventory::AnsibleTower
         # opts = {:fetch_all_pages => true, :accept_encoding => 'gzip', :apply_filter => nil}
         receptor_params = {:accept_encoding => 'gzip', :fetch_all_pages => true}
         query_params    = {:page_size => limits[entity_type]}
+        query_params[:modified__gt] = last_modified_at if scheduler.do_partial_refresh?(source)
         send("get_#{entity_type}", connection, query_params,
              :on_premise => true, :receptor_receiver => receiver, :receptor_params => receptor_params)
       end

--- a/lib/topological_inventory/ansible_tower/receptor/collector.rb
+++ b/lib/topological_inventory/ansible_tower/receptor/collector.rb
@@ -29,7 +29,13 @@ module TopologicalInventory::AnsibleTower
 
         logger.collecting(:start, source, entity_type, refresh_state_uuid)
 
-        receiver = AsyncReceiver.new(self, connection, entity_type, refresh_state_uuid, refresh_state_started_at)
+        sweeping_disabled = scheduler.do_partial_refresh?(source) && last_modified_at.present?
+        receiver = AsyncReceiver.new(self,
+                                     connection,
+                                     entity_type,
+                                     refresh_state_uuid,
+                                     refresh_state_started_at,
+                                     :sweeping_enabled => !sweeping_disabled)
 
         # opts = {:fetch_all_pages => true, :accept_encoding => 'gzip', :apply_filter => nil}
         receptor_params = {:accept_encoding => 'gzip', :fetch_all_pages => true}
@@ -49,6 +55,7 @@ module TopologicalInventory::AnsibleTower
         save_inventory(parser.collections.values, inventory_name, schema_name, refresh_state_uuid, refresh_state_part_uuid, refresh_state_part_collected_at)
       end
 
+      # Not called by partial refresh
       def async_sweep_inventory(refresh_state_uuid, sweep_scope, total_parts, refresh_state_started_at)
         logger.sweeping(:start, source, sweep_scope, refresh_state_uuid)
 

--- a/spec/cloud/collector_spec.rb
+++ b/spec/cloud/collector_spec.rb
@@ -1,0 +1,60 @@
+require 'topological_inventory/ansible_tower/collector/scheduler'
+require 'timecop'
+
+describe TopologicalInventory::AnsibleTower::Cloud::Collector do
+  let(:connection) { double('connection') }
+  let(:scheduler) { TopologicalInventory::AnsibleTower::Collector::Scheduler.new }
+  let(:source_uid) { '7b901ca3-5414-4476-8d48-a722c1493de0' }
+
+  subject do
+    described_class.new(source_uid,
+                        'tower.example.com',
+                        'user', 'passwd',
+                        nil)
+  end
+
+  context "on partial refresh" do
+    before do
+      allow(subject).to receive(:scheduler).and_return(scheduler)
+    end
+
+    describe "#collector_thread" do
+      let(:entity_type) { 'service_offerings' }
+
+      before do
+        @start_time = Time.now.utc
+        Timecop.freeze(@start_time)
+
+        scheduler.full_refresh_started!(source_uid)
+        scheduler.full_refresh_finished!(source_uid)
+
+        Timecop.travel(@start_time + scheduler.send(:partial_refresh_frequency))
+        scheduler.partial_refresh_started!(source_uid)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      it "creates API call with timestamp when partial refresh" do
+        expect(subject.send(:last_modified_at)).to eq(@start_time.iso8601)
+
+        expect(subject).to(receive(:get_service_offerings)
+                             .with(connection, hash_including(:modified__gt => @start_time.iso8601))
+                             .and_return([]))
+        subject.send(:collector_thread, connection, entity_type)
+      end
+
+      it "skips sweeping when partial refresh" do
+        allow(subject).to(receive(:get_service_offerings).twice.and_return([]))
+
+        expect(subject).to receive(:sweep_inventory).once
+
+        subject.send(:collector_thread, double('connection'), entity_type)
+
+        allow(scheduler).to receive(:do_partial_refresh?).and_return(false)
+        subject.send(:collector_thread, double('connection'), entity_type)
+      end
+    end
+  end
+end

--- a/spec/collector/scheduler_spec.rb
+++ b/spec/collector/scheduler_spec.rb
@@ -1,0 +1,142 @@
+require 'topological_inventory/ansible_tower/collector/scheduler'
+require 'timecop'
+
+RSpec.describe TopologicalInventory::AnsibleTower::Collector::Scheduler do
+  let(:source_uid) { '09d1ac7c-a9db-46d0-8a65-e8c4aafbeaa4' }
+  subject { described_class.new }
+
+  around do |example|
+    ENV["COLLECTOR_FULL_REFRESH_FREQUENCY"] = '10'
+    ENV["COLLECTOR_PARTIAL_REFRESH_FREQUENCY"] = '5'
+
+    @start_time = Time.now.utc
+    Timecop.freeze(@start_time)
+
+    example.run
+
+    Timecop.return
+    ENV["COLLECTOR_FULL_REFRESH_FREQUENCY"] = nil
+    ENV["COLLECTOR_PARTIAL_REFRESH_FREQUENCY"] = nil
+  end
+
+  describe "#do_full_refresh?" do
+    it "returns true if no timestamp found" do
+      expect(subject.do_full_refresh?(source_uid)).to be_truthy
+    end
+
+    it "returns T/F regarding last full refresh reached threshold" do
+      subject.full_refresh_started!(source_uid)
+      subject.full_refresh_finished!(source_uid)
+
+      Timecop.travel(@start_time + 1.second)
+      expect(subject.do_full_refresh?(source_uid)).to be_falsey
+
+      Timecop.travel(@start_time + subject.full_refresh_frequency.seconds)
+      expect(subject.do_full_refresh?(source_uid)).to be_truthy
+    end
+  end
+
+  describe "#do_partial_refresh?" do
+    it "returns false if full_refresh is needed" do
+      subject.add_source(source_uid)
+
+      expect(subject.do_full_refresh?(source_uid)).to be_truthy
+      expect(subject.do_partial_refresh?(source_uid)).to be_falsey
+    end
+
+    it "returns T/F if full_refresh was done and last partial refresh reached threshold" do
+      allow(subject).to receive(:do_full_refresh?).and_return(false)
+
+      subject.add_source(source_uid)
+
+      subject.partial_refresh_started!(source_uid)
+      subject.partial_refresh_finished!(source_uid)
+
+      Timecop.travel(@start_time + 1.second)
+      expect(subject.do_partial_refresh?(source_uid)).to be_falsey
+
+      Timecop.travel(@start_time + subject.partial_refresh_frequency.seconds)
+      expect(subject.do_partial_refresh?(source_uid)).to be_truthy
+    end
+  end
+
+  describe "#do_refresh?" do
+    it "return true if either full or partial refresh needs to be run" do
+      subject.add_source(source_uid)
+
+      allow(subject).to receive(:do_full_refresh?).and_return(false)
+      allow(subject).to receive(:do_partial_refresh?).and_return(false)
+
+      expect(subject.do_refresh?(source_uid)).to be_falsey
+
+      allow(subject).to receive(:do_full_refresh?).and_return(true)
+      allow(subject).to receive(:do_partial_refresh?).and_return(false)
+
+      expect(subject.do_refresh?(source_uid)).to be_truthy
+
+      allow(subject).to receive(:do_full_refresh?).and_return(false)
+      allow(subject).to receive(:do_partial_refresh?).and_return(false)
+
+      expect(subject.do_refresh?(source_uid)).to be_falsey
+    end
+  end
+
+  describe "#full_refresh_started!" do
+    it "sets start time of full refresh" do
+      subject.full_refresh_started!(source_uid)
+
+      timestamps = subject.send(:timestamps)[source_uid]
+      expect(timestamps[:full_refresh][:started_at]).to eq(@start_time)
+    end
+  end
+
+  describe "#full_refresh_finished!" do
+    it "sets last refresh time of both full AND partial refresh to start_time" do
+      subject.full_refresh_started!(source_uid)
+      Timecop.travel(@start_time + 100.seconds)
+      subject.full_refresh_finished!(source_uid)
+
+      timestamps = subject.send(:timestamps)[source_uid]
+      expect(timestamps[:full_refresh][:last_finished_at]).to eq(@start_time)
+      expect(timestamps[:partial_refresh][:last_finished_at]).to eq(@start_time)
+    end
+  end
+
+  describe "#partial_refresh_finished!" do
+    it "sets last refresh time of partial refresh" do
+      subject.partial_refresh_started!(source_uid)
+      Timecop.travel(@start_time + 100.seconds)
+      subject.partial_refresh_finished!(source_uid)
+
+      timestamps = subject.send(:timestamps)[source_uid]
+      expect(timestamps[:full_refresh][:last_finished_at]).to be_nil
+      expect(timestamps[:partial_refresh][:last_finished_at]).to eq(@start_time)
+    end
+
+    it "raises an exception if neither full nor partial refresh started before" do
+      expect { subject.partial_refresh_finished!(source_uid) }.to raise_exception("Refresh started_at for source #{source_uid} is missing!")
+    end
+  end
+
+  describe "#last_partial_refresh_at" do
+    it "returns nil if source wasn't registered (it means full-refresh)" do
+      expect(subject.last_partial_refresh_at(source_uid)).to be_nil
+    end
+
+    it "returns timestamp of last finished partial refresh" do
+      subject.partial_refresh_started!(source_uid)
+      subject.partial_refresh_finished!(source_uid)
+      timestamps = subject.send(:timestamps)[source_uid]
+      expect(timestamps[:partial_refresh][:last_finished_at]).to eq(@start_time)
+
+      expect(subject.last_partial_refresh_at(source_uid)).to eq(@start_time)
+    end
+
+    it "returns timestamp of last finished full refresh if no partial_refresh was ran before" do
+      subject.full_refresh_started!(source_uid)
+      subject.full_refresh_finished!(source_uid)
+
+      expect(subject.last_partial_refresh_at(source_uid)).to eq(@start_time)
+    end
+  end
+end

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -1,19 +1,43 @@
+require 'topological_inventory/ansible_tower/collector/scheduler'
+
 RSpec.describe TopologicalInventory::AnsibleTower::Collector do
   let(:source_uid) { '7b901ca3-5414-4476-8d48-a722c1493de0' }
   let(:logger) { double('Logger').as_null_object }
-  let(:client) { double('Ingress API Client') }
+  let(:scheduler) { TopologicalInventory::AnsibleTower::Collector::Scheduler.new }
 
   subject do
     described_class.new(source_uid,
-                        'tower.example.com',
-                        'user',
-                        'passwd',
-                        nil)
+                        nil,
+                        :poll_time => 1)
 
   end
 
   before do
     allow(subject).to receive(:logger).and_return(logger)
-    allow(subject).to receive(:ingress_api_client).and_return(client)
+  end
+
+  describe "#collect!" do
+    before do
+      # collect only once
+      allow(subject).to receive(:standalone_mode).and_return(false)
+      allow(subject).to receive(:scheduler).and_return(scheduler)
+    end
+
+    it "collects only if it's allowed by the scheduler" do
+      %i[refresh_started
+         refresh_finished
+         ensure_collector_threads
+         wait_for_collected_data].each do |method|
+        expect(subject).to receive(method).and_return(nil).once
+      end
+
+      allow(scheduler).to receive(:do_refresh?).and_return(false)
+      subject.collect!
+
+      subject.send(:finished).value = false
+
+      allow(scheduler).to receive(:do_refresh?).and_return(true)
+      subject.collect!
+    end
   end
 end

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -3,11 +3,12 @@ require 'topological_inventory/ansible_tower/collector/scheduler'
 RSpec.describe TopologicalInventory::AnsibleTower::Collector do
   let(:source_uid) { '7b901ca3-5414-4476-8d48-a722c1493de0' }
   let(:logger) { double('Logger').as_null_object }
+  let(:metrics) { double('Metrics') }
   let(:scheduler) { TopologicalInventory::AnsibleTower::Collector::Scheduler.new }
 
   subject do
     described_class.new(source_uid,
-                        nil,
+                        metrics,
                         :poll_time => 1)
 
   end
@@ -38,6 +39,13 @@ RSpec.describe TopologicalInventory::AnsibleTower::Collector do
 
       allow(scheduler).to receive(:do_refresh?).and_return(true)
       subject.collect!
+    end
+  end
+
+  describe "#refresh_finished" do
+    it "catches an exception if called without refresh_start" do
+      expect(metrics).to receive(:record_error)
+      subject.send(:refresh_finished, :partial_refresh)
     end
   end
 end

--- a/spec/collectors_pool_spec.rb
+++ b/spec/collectors_pool_spec.rb
@@ -1,3 +1,5 @@
+require 'topological_inventory/ansible_tower/collector/scheduler'
+
 RSpec.describe TopologicalInventory::AnsibleTower::CollectorsPool do
   let(:source) { double("Source") }
 
@@ -32,6 +34,12 @@ RSpec.describe TopologicalInventory::AnsibleTower::CollectorsPool do
   end
 
   describe ".new_collector" do
+    let(:scheduler) { TopologicalInventory::AnsibleTower::Collector::Scheduler.new }
+
+    before do
+      allow(subject).to receive(:scheduler).and_return(scheduler)
+    end
+
     it "creates public tower's collector if receptor_node blank" do
       allow(source).to receive_messages(:source        => SecureRandom.uuid,
                                         :scheme        => 'http',
@@ -39,6 +47,8 @@ RSpec.describe TopologicalInventory::AnsibleTower::CollectorsPool do
                                         :port          => 80,
                                         :receptor_node => nil)
       secret = {'username' => 'redhat', 'password' => 'secret_password'}
+
+      expect(scheduler).to receive(:add_source).with(source.source)
 
       collector = subject.new_collector(source, secret)
       expect(collector).to be_instance_of(TopologicalInventory::AnsibleTower::Cloud::Collector)
@@ -48,6 +58,8 @@ RSpec.describe TopologicalInventory::AnsibleTower::CollectorsPool do
       allow(source).to receive_messages(:source         => SecureRandom.uuid,
                                         :account_number => '123456',
                                         :receptor_node  => 'sample-node')
+
+      expect(scheduler).to receive(:add_source).with(source.source)
 
       collector = subject.new_collector(source, {})
       expect(collector).to be_instance_of(TopologicalInventory::AnsibleTower::Receptor::Collector)

--- a/spec/receptor/collector_spec.rb
+++ b/spec/receptor/collector_spec.rb
@@ -1,12 +1,21 @@
+require 'topological_inventory/ansible_tower/collector/scheduler'
+require 'topological_inventory/ansible_tower/receptor/async_receiver'
+require 'timecop'
+
 RSpec.describe TopologicalInventory::AnsibleTower::Receptor::Collector do
   let(:account_number) { '1234' }
   let(:inventory_name) { 'AnsibleTower' }
   let(:schema_name) { 'Default' }
   let(:metrics) { double('metrics') }
   let(:receptor_node) { 'sample-node' }
+  let(:scheduler) { TopologicalInventory::AnsibleTower::Collector::Scheduler.new }
   let(:source_uid) { '7b901ca3-5414-4476-8d48-a722c1493de0' }
 
   subject { described_class.new(source_uid, receptor_node, account_number, metrics) }
+
+  before do
+    allow(subject).to receive(:scheduler).and_return(scheduler)
+  end
 
   describe "#connection_for_entity_type" do
     before do
@@ -23,17 +32,59 @@ RSpec.describe TopologicalInventory::AnsibleTower::Receptor::Collector do
     let(:entity_type) { 'service_offerings' }
     let(:receiver) { double('Async receiver') }
 
-    it "invokes on-premise requests" do
-      expect(TopologicalInventory::AnsibleTower::Receptor::AsyncReceiver).to receive(:new).and_return(receiver)
+    context "running full-refresh" do
+      before do
+        allow(scheduler).to receive(:do_partial_refresh?).and_return(false)
+      end
 
-      expect(subject).to(receive(:get_service_offerings)
-                           .with(connection,
-                                 {:page_size => subject.send(:limits)[entity_type]},
-                                 :on_premise        => true,
-                                 :receptor_receiver => receiver,
-                                 :receptor_params   => {:accept_encoding => 'gzip', :fetch_all_pages => true}))
+      it "invokes on-premise requests" do
+        expect(TopologicalInventory::AnsibleTower::Receptor::AsyncReceiver).to receive(:new).and_return(receiver)
 
-      subject.collector_thread(connection, entity_type)
+        expect(subject).to(receive(:get_service_offerings)
+                             .with(connection,
+                                   {:page_size => subject.send(:limits)[entity_type]},
+                                   {:on_premise        => true,
+                                    :receptor_receiver => receiver,
+                                    :receptor_params   => {:accept_encoding => 'gzip', :fetch_all_pages => true}}))
+
+        subject.collector_thread(connection, entity_type)
+      end
+    end
+
+    context "running partial-refresh" do
+      before do
+        @start_time = Time.now.utc
+        Timecop.freeze(@start_time)
+
+        scheduler.full_refresh_started!(source_uid)
+        scheduler.full_refresh_finished!(source_uid)
+
+        Timecop.travel(@start_time + scheduler.send(:partial_refresh_frequency))
+        scheduler.partial_refresh_started!(source_uid)
+      end
+
+      after { Timecop.return }
+
+      it "creates receiver with sweeping disabled and querying with timestamp" do
+        receiver_class = TopologicalInventory::AnsibleTower::Receptor::AsyncReceiver
+        expect(receiver_class).to(receive(:new)
+                                    .with(subject,
+                                          connection,
+                                          entity_type,
+                                          anything, anything,
+                                          :sweeping_enabled => false)
+                                    .and_return(receiver))
+
+        expect(subject).to(receive(:get_service_offerings)
+                             .with(connection,
+                                   {:page_size    => subject.send(:limits)[entity_type],
+                                    :modified__gt => @start_time.iso8601},
+                                   {:on_premise        => true,
+                                    :receptor_receiver => receiver,
+                                    :receptor_params   => {:accept_encoding => 'gzip', :fetch_all_pages => true}}))
+
+        subject.collector_thread(connection, entity_type)
+      end
     end
   end
 


### PR DESCRIPTION
Partial refresh is adding `modified__gt=<Time in ISO8601>` param to API calls.

It's using internal scheduler so first refresh is always full, then they are mixed in interval specified by ENV variables:
- `ENV['COLLECTOR_FULL_REFRESH_FREQUENCY'] || 3600 # seconds`
- `ENV['COLLECTOR_PARTIAL_REFRESH_FREQUENCY'] || 300`
- - `ENV['COLLECTOR_POLL_TIME']` is here for compatibility

The full refresh has to be repeated time to time from several reasons:

1. Sweeping (archiving) of items which were not collected 
2. Some values don't update the `modified` timestamp in Tower (tested on 3.7.0):
- changed nodes in workflow template (i.e. from "always" to "on failure") - we're collecting them, but afaik not using them
- credentials of workflow job template nodes

---

- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-orchestrator/pull/110

---

[RHCLOUD-9410](https://issues.redhat.com/browse/RHCLOUD-9410)
