### PR TITLE
Targeted refresh: archiving deleted jobs

### DIFF
--- a/lib/topological_inventory/ansible_tower/targeted_refresh/service_instance.rb
+++ b/lib/topological_inventory/ansible_tower/targeted_refresh/service_instance.rb
@@ -3,6 +3,8 @@ require "topological_inventory/providers/common/operations/source"
 require "topological_inventory/providers/common/mixins/sources_api"
 require "topological_inventory/providers/common/mixins/x_rh_headers"
 require "topological_inventory/ansible_tower/receptor/async_receiver"
+require 'concurrent'
+require 'time'
 
 module TopologicalInventory
   module AnsibleTower
@@ -34,7 +36,10 @@ module TopologicalInventory
           logger.info_ext(operation, "Connection set successfully")
 
           # Get all tasks
-          tasks, refresh_state_uuid = {}, SecureRandom.uuid
+          tasks, @refresh_state_uuid = {}, SecureRandom.uuid
+          @parts_requested_cnt, @parts_received_cnt = Concurrent::AtomicFixnum.new(0), Concurrent::AtomicFixnum.new(0)
+          @source_refs_requested, @source_refs_received = [], Concurrent::Array.new
+
           params.to_a.each do |task|
             if task['task_id'].blank? || task['source_ref'].blank?
               logger.warn_ext(operation, "Missing data for task: #{task}")
@@ -43,12 +48,14 @@ module TopologicalInventory
             tasks[task['task_id']] = task['source_ref']
 
             if tasks.length == REFS_PER_REQUEST_LIMIT
-              refresh_part(tasks, refresh_state_uuid, SecureRandom.uuid)
+              refresh_part(tasks, @refresh_state_uuid, SecureRandom.uuid)
               tasks = {}
             end
           end
 
-          refresh_part(tasks, refresh_state_uuid, SecureRandom.uuid) unless tasks.empty?
+          refresh_part(tasks, @refresh_state_uuid, SecureRandom.uuid) unless tasks.empty?
+
+          archive_not_received_service_instances unless on_premise?
         rescue => err
           logger.error_ext(operation, "Error: #{err.message}\n#{err.backtrace.join("\n")}")
         end
@@ -57,10 +64,15 @@ module TopologicalInventory
           refresh_state_part_collected_at = Time.now.utc
           refresh_state_part_uuid = SecureRandom.uuid
           save_inventory(parser.collections.values, inventory_name, schema_name, refresh_state_uuid, refresh_state_part_uuid, refresh_state_part_collected_at)
+
+          remember_received_service_instances(parser)
         end
 
         def async_collecting_finished(entity_type, refresh_state_uuid, total_parts)
           logger.info_ext(operation, "Finished collecting of #{entity_type} (#{refresh_state_uuid}). Total parts: #{total_parts}")
+          @parts_received_cnt.increment
+
+          archive_not_received_service_instances if @parts_requested_cnt == @parts_received_cnt.value
         end
 
         private
@@ -91,6 +103,9 @@ module TopologicalInventory
             :id__in    => tasks.values.join(','),
             :page_size => limits['service_instances']
           }
+
+          @parts_requested_cnt.increment
+          @source_refs_requested += tasks.values
 
           if on_premise?
             refresh_part_on_premise(tasks_id, refresh_state_uuid, query_params)
@@ -124,6 +139,9 @@ module TopologicalInventory
           # Sending to Ingress API
           logger.info_ext(operation, "Task[ id: #{tasks_id} ] Sending to Ingress API...")
           save_inventory(parser.collections.values, inventory_name, schema_name, refresh_state_uuid, refresh_state_part_uuid)
+
+          remember_received_service_instances(parser)
+
           logger.info_ext(operation, "Task[ id: #{tasks_id} ] Sending to Ingress API...Complete")
         end
 
@@ -151,6 +169,29 @@ module TopologicalInventory
           end
 
           self.tower_hostname = full_hostname(endpoint)
+        end
+
+        def remember_received_service_instances(parser)
+          @source_refs_received += parser.collections[:service_instances]&.data&.map(&:source_ref).to_a
+        end
+
+        # source_refs not received were deleted in Tower => has to be archived
+        def archive_not_received_service_instances
+          not_received = @source_refs_requested - @source_refs_received
+          if not_received.present?
+            archived_at = Time.now.utc.iso8601
+            collection = TopologicalInventoryIngressApiClient::InventoryCollectionServiceInstance.new(:name => :service_instances, :data => [])
+
+            not_received.each do |source_ref|
+              svc_instance = TopologicalInventoryIngressApiClient::ServiceInstance.new(:archived_at => archived_at,
+                                                                                       :extra       => {:status => 'deleted', :task_status => 'error'},
+                                                                                       :source_ref  => source_ref)
+              collection.data << svc_instance
+            end
+            logger.info("ServiceInstance#refresh - Archiving (source_refs: #{not_received.join(',')}). Jobs were deleted...")
+            save_inventory([collection], inventory_name, schema_name, @refresh_state_uuid, SecureRandom.uuid)
+            logger.info("ServiceInstance#refresh - Archiving (source_refs: #{not_received.join(',')}). Complete")
+          end
         end
 
         def default_refresh_type


### PR DESCRIPTION
Targeted refresh requests jobs in batches. Jobs which are not received back are considered as deleted and sent to Ingress API as archived

---

- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-core/pull/210
- [x] **depends on** https://github.com/RedHatInsights/topological_inventory-persister/pull/72
---

[RHCLOUD-9508](https://issues.redhat.com/browse/RHCLOUD-9508)