### PR TITLE
Use Async Operations Worker class for Source.availability_check messages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "receptor_controller-client", :git => 'https://github.com/lindgrenj6/recepto
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 1.0.10"
+gem "topological_inventory-providers-common", "~> 1.0.12"
 group :development, :test do
   gem "rspec"
   gem 'rubocop', "~>0.69.0"

--- a/Gemfile
+++ b/Gemfile
@@ -8,14 +8,14 @@ gem "ansible_tower_client", "~> 0.21.0"
 gem "cloudwatchlogger", "~> 0.2.1"
 gem "concurrent-ruby"
 gem "manageiq-loggers",   "~> 0.5.0"
-gem "manageiq-messaging", :git => 'https://github.com/bzwei/manageiq-messaging', :branch => 'rdkafka'
+gem "manageiq-messaging", "~> 1.0.0"
 gem "more_core_extensions"
 gem "optimist"
 gem "prometheus_exporter", "~> 0.4.5"
 gem "rake", ">= 12.3.3"
 gem "rest-client", "~>2.0"
 
-gem "receptor_controller-client", :git => 'https://github.com/lindgrenj6/receptor_controller-client-ruby', :branch => 'rdkafka'
+gem "receptor_controller-client", "~> 0.0.7"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"

--- a/lib/topological_inventory/ansible_tower/operations/worker.rb
+++ b/lib/topological_inventory/ansible_tower/operations/worker.rb
@@ -4,6 +4,7 @@ require "topological_inventory/ansible_tower/operations/source"
 require "topological_inventory/ansible_tower/connection_manager"
 require "topological_inventory/ansible_tower/messaging_client"
 require "topological_inventory/providers/common/operations/health_check"
+require "topological_inventory/providers/common/operations/async_worker"
 
 module TopologicalInventory
   module AnsibleTower
@@ -11,22 +12,30 @@ module TopologicalInventory
       class Worker
         include Logging
 
+        ASYNC_MESSAGES = %w[Source.availability_check].freeze
+
         def run
-          TopologicalInventory::AnsibleTower::ConnectionManager.start_receptor_client
-          sleep 5
+          start_workers
           logger.info("Topological Inventory AnsibleTower Operations worker started...")
 
           client.subscribe_topic(queue_opts) do |message|
             log_with(message.payload&.fetch_path('request_context', 'x-rh-insights-request-id')) do
-              model, method = message.message.to_s.split(".")
-              logger.info("Received message #{model}##{method}, #{message.payload}")
-              process_message(message)
+              if ASYNC_MESSAGES.include?(message.message)
+                logger.debug("Queuing #{message.message} message for asynchronous processing...")
+                async_queue << message
+              else
+                model, method = message.message.to_s.split(".")
+                logger.info("Received message #{model}##{method}, #{message.payload}")
+
+                process_message(message)
+              end
             end
           end
         rescue => err
           logger.error("#{err.cause}\n#{err.backtrace.join("\n")}")
         ensure
           client&.close
+          async_worker&.exit
           TopologicalInventory::AnsibleTower::ConnectionManager.stop_receptor_client
         end
 
@@ -40,6 +49,14 @@ module TopologicalInventory
           TopologicalInventory::AnsibleTower::MessagingClient.default.worker_listener_queue_opts
         end
 
+        def async_worker
+          @async_worker ||= TopologicalInventory::Providers::Common::Operations::AsyncWorker.new(async_queue, Processor).run
+        end
+
+        def async_queue
+          @async_queue ||= Queue.new
+        end
+
         def process_message(message)
           Processor.process!(message)
         rescue StandardError => err
@@ -50,6 +67,11 @@ module TopologicalInventory
         ensure
           message.ack
           TopologicalInventory::Providers::Common::Operations::HealthCheck.touch_file
+        end
+
+        def start_workers
+          TopologicalInventory::AnsibleTower::ConnectionManager.start_receptor_client
+          async_worker
         end
       end
     end


### PR DESCRIPTION
*Depends on*: 
- [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/55 (add class)
- [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/56 (release v1.0.12)

----

https://issues.redhat.com/browse/RHCLOUD-9652

The client-side changes for this bug. Basically instantiate an `AsyncWorker` and then send any messages that are `Source#availability_check` over there so any ordering/applied inventories messages don't get blocked by all of the availability check messages. 

We can add any messages we want to the `ASYNC_MESSAGES` array constant, so we can really dial it down to spend the most time on what needs to be processed immediately.

cc @syncrou @slemrmartin 