### PR TITLE
MessagingClient code cleanup.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "receptor_controller-client", "~> 0.0.7"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 2.0.0"
+gem "topological_inventory-providers-common", "~> 2.1.1"
 group :development, :test do
   gem "rspec"
   gem "rubocop", "~> 1.0.0"

--- a/lib/topological_inventory/ansible_tower/messaging_client.rb
+++ b/lib/topological_inventory/ansible_tower/messaging_client.rb
@@ -2,31 +2,9 @@ require "manageiq-messaging"
 
 module TopologicalInventory
   module AnsibleTower
-    class MessagingClient
+    class MessagingClient < TopologicalInventory::Providers::Common::MessagingClient
       OPERATIONS_QUEUE_NAME = "platform.topological-inventory.operations-ansible-tower".freeze
       REFRESH_QUEUE_NAME = "platform.topological-inventory.collector-ansible-tower".freeze
-
-      # Kafka host name
-      attr_accessor :queue_host
-      # Kafka port
-      attr_accessor :queue_port
-
-      def initialize
-        @queue_host = 'localhost'
-        @queue_port = 9092
-      end
-
-      def self.default
-        @@default ||= new
-      end
-
-      def self.configure
-        if block_given?
-          yield(default)
-        else
-          default
-        end
-      end
 
       # Instance of messaging client for Worker
       def worker_listener

--- a/spec/operations/worker_spec.rb
+++ b/spec/operations/worker_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe TopologicalInventory::AnsibleTower::Operations::Worker do
       allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
       allow(client).to receive(:close)
       allow(subject).to receive(:logger).and_return(double('null_object').as_null_object)
+      TopologicalInventory::AnsibleTower::MessagingClient.class_variable_set(:@@default, nil)
     end
 
     it "calls subscribe_messages on the right queue" do


### PR DESCRIPTION
Moving some parts of the MessagingClient code into the ancestor.

depends on: 
 - [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/54
 - [x] https://github.com/RedHatInsights/topological_inventory-providers-common/pull/58


This PR is based on the https://issues.redhat.com/browse/RHCLOUD-9328