### PR TITLE
Rubocop rules from insights-api-common + yamllint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -20,12 +20,12 @@ checks:
     enabled: false
 prepare:
   fetch:
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
     path: ".rubocop_base.yml"
-  - url: https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_cc_base.yml
+  - url: https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_cc_base.yml
     path: ".rubocop_cc_base.yml"
 plugins:
   rubocop:
     enabled: true
     config: ".rubocop_cc.yml"
-    channel: rubocop-0-69
+    channel: rubocop-1-0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,3 @@
 inherit_from:
-- https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml
+- https://raw.githubusercontent.com/RedHatInsights/insights-api-common-rails/master/.rubocop_base.yml
 - .rubocop_local.yml

--- a/Gemfile
+++ b/Gemfile
@@ -22,8 +22,9 @@ gem "topological_inventory-ingress_api-client", "~> 1.0.1"
 gem "topological_inventory-providers-common", "~> 2.0.0"
 group :development, :test do
   gem "rspec"
-  gem 'rubocop', "~>0.69.0"
-  gem 'rubocop-performance', "~>1.3"
+  gem "rubocop", "~> 1.0.0"
+  gem "rubocop-performance", "~> 1.8"
+  gem "rubocop-rails", "~> 2.8"
   gem "simplecov", "~> 0.17.1"
   gem "webmock"
 end


### PR DESCRIPTION
Because of https://github.com/ManageIQ/guides/pull/443 rubocop rules were moved to another repo. 
So we are moving the file to our common repo.

* [x] depends on https://github.com/RedHatInsights/insights-api-common-rails/pull/211

---

[RHCLOUD-10237](https://issues.redhat.com/browse/RHCLOUD-10237)
