### PR TITLE
Custom metrics for operations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "receptor_controller-client", "~> 0.0.7"
 gem "sources-api-client", "~> 3.0"
 gem "topological_inventory-api-client", "~> 3.0"
 gem "topological_inventory-ingress_api-client", "~> 1.0.1"
-gem "topological_inventory-providers-common", "~> 2.1.1"
+gem "topological_inventory-providers-common", "~> 2.1.2"
 group :development, :test do
   gem "rspec"
   gem "rubocop", "~> 1.0.0"

--- a/bin/ansible_tower-operations
+++ b/bin/ansible_tower-operations
@@ -4,10 +4,14 @@ $LOAD_PATH << File.expand_path("../lib", __dir__)
 require "bundler/setup"
 require "active_support/core_ext/object/blank"
 require "optimist"
+require "topological_inventory/ansible_tower/operations/metrics"
 require "topological_inventory/ansible_tower/operations/worker"
 
 def parse_args
   Optimist.options do
+    opt :metrics_port, "Port to expose the metrics endpoint on, 0 to disable metrics",
+        :type => :integer, :default => (ENV["METRICS_PORT"] || 9394).to_i
+
     opt :queue_host, "Kafka messaging: hostname or IP", :type => :string, :default => ENV["QUEUE_HOST"] || "localhost"
     opt :queue_port, "Kafka messaging: port", :type => :integer, :default => (ENV["QUEUE_PORT"] || 9092).to_i
 
@@ -62,8 +66,15 @@ TopologicalInventory::AnsibleTower::MessagingClient.configure do |config|
   config.queue_port = args[:queue_port]
 end
 
+metrics           = TopologicalInventory::AnsibleTower::Operations::Metrics.new(args[:metrics_port])
+operations_worker = TopologicalInventory::AnsibleTower::Operations::Worker.new(metrics)
+
+Signal.trap("TERM") do
+  metrics.stop_server
+  exit
+end
+
 begin
-  operations_worker = TopologicalInventory::AnsibleTower::Operations::Worker.new
   operations_worker.run
 rescue => err
   puts err

--- a/lib/topological_inventory/ansible_tower/operations/metrics.rb
+++ b/lib/topological_inventory/ansible_tower/operations/metrics.rb
@@ -1,0 +1,17 @@
+require 'topological_inventory/providers/common/metrics'
+
+module TopologicalInventory
+  module AnsibleTower
+    module Operations
+      class Metrics < TopologicalInventory::Providers::Common::Metrics
+        def initialize(port = 9394)
+          super(port)
+        end
+
+        def default_prefix
+          "topological_inventory_ansible_tower_operations_"
+        end
+      end
+    end
+  end
+end

--- a/lib/topological_inventory/ansible_tower/operations/processor.rb
+++ b/lib/topological_inventory/ansible_tower/operations/processor.rb
@@ -1,54 +1,16 @@
 require "topological_inventory/ansible_tower/logging"
-require "topological_inventory/providers/common/mixins/topology_api"
 require "topological_inventory/ansible_tower/operations/service_offering"
+require "topological_inventory/ansible_tower/operations/source"
+require "topological_inventory/providers/common/operations/processor"
 
 module TopologicalInventory
   module AnsibleTower
     module Operations
-      class Processor
+      class Processor < TopologicalInventory::Providers::Common::Operations::Processor
         include Logging
-        include TopologicalInventory::Providers::Common::Mixins::TopologyApi
 
-        def self.process!(message)
-          model, method = message.message.to_s.split(".")
-          new(model, method, message.payload).process
-        end
-
-        # @param payload [Hash] https://github.com/ManageIQ/topological_inventory-api/blob/master/app/controllers/api/v0/service_plans_controller.rb#L32-L41
-        def initialize(model, method, payload)
-          self.model    = model
-          self.method   = method
-          self.params   = payload["params"]
-          self.identity = payload["request_context"]
-        end
-
-        def process
-          logger.info(status_log_msg)
-          impl = "#{Operations}::#{model}".safe_constantize&.new(params, identity)
-          if impl&.respond_to?(method)
-            result = impl&.send(method)
-
-            logger.info(status_log_msg("Complete"))
-            result
-          else
-            logger.warn(status_log_msg("Not Implemented!"))
-            if params['task_id']
-              update_task(params['task_id'],
-                          :state   => "completed",
-                          :status  => "error",
-                          :context => {:error => "#{model}##{method} not implemented"})
-            end
-          end
-        end
-
-        private
-
-        attr_accessor :identity, :model, :method, :params
-
-        def status_log_msg(status = nil)
-          log_task_text = "Task(id: #{params['task_id']}): " if params['task_id']
-
-          "#{log_task_text}Processing #{model}##{method} [#{params}]...#{status}"
+        def operation_class
+          "#{Operations}::#{model}".safe_constantize
         end
       end
     end

--- a/lib/topological_inventory/ansible_tower/operations/service_offering.rb
+++ b/lib/topological_inventory/ansible_tower/operations/service_offering.rb
@@ -5,19 +5,20 @@ module TopologicalInventory
   module AnsibleTower
     module Operations
       class ServiceOffering
-        attr_accessor :params, :identity
+        attr_accessor :metrics, :params, :identity
 
-        def initialize(params = {}, identity = nil)
+        def initialize(params = {}, identity = nil, metrics = nil)
           @params   = params
           @identity = identity
+          @metrics  = metrics
         end
 
         def order
-          Order::Request.new(params, identity).run
+          Order::Request.new(params, identity, metrics).run
         end
 
         def applied_inventories
-          AppliedInventories::Request.new(params, identity).run
+          AppliedInventories::Request.new(params, identity, metrics).run
         end
       end
     end

--- a/spec/operations/processor_spec.rb
+++ b/spec/operations/processor_spec.rb
@@ -1,25 +1,63 @@
 require "topological_inventory/ansible_tower/operations/processor"
 
 RSpec.describe TopologicalInventory::AnsibleTower::Operations::Processor do
-  context "#process" do
-    it "updates task with not_implemented error if operation not supported" do
-      # Non-existing class
-      task_id = '1'
-      processor = described_class.new('SomeModel', 'some_method', {'params' => {'task_id' => task_id}})
-      expect(processor).to receive(:update_task).with(task_id,
-                                                      :state   => 'completed',
-                                                      :status  => 'error',
-                                                      :context => {:error => "SomeModel#some_method not implemented"})
-      processor.process
+  let(:message) { double("ManageIQ::Messaging::ReceivedMessage", :message => operation_name, :payload => payload) }
+  let(:operation_name) { 'Testing.operation' }
+  let(:params) { {'source_id' => 1, 'external_tenant' => '12345', 'task_id' => task_id} }
+  let(:payload) { {"params" => params, "request_context" => double('request_context')} }
+  let(:task_id) { '42' }
 
-      # Non-existing method
-      task_id = '2'
-      processor = described_class.new('ServiceOffering', 'some_method', {'params' => {'task_id' => task_id}})
-      expect(processor).to receive(:update_task).with(task_id,
-                                                      :state   => 'completed',
-                                                      :status  => 'error',
-                                                      :context => {:error => "ServiceOffering#some_method not implemented"})
-      processor.process
+  subject { described_class.new(message, nil) }
+
+  describe "#process" do
+    context "ServiceOffering" do
+      let(:svc_offering_class) { TopologicalInventory::AnsibleTower::Operations::ServiceOffering }
+      let(:service_offering) { svc_offering_class.new(params) }
+      let(:operation) { double('Operation object') }
+
+      before do
+        allow(svc_offering_class).to receive(:new).and_return(service_offering)
+      end
+
+      context "ordering task" do
+        let(:operation_name) { 'ServiceOffering.order' }
+
+        it "orders service offering" do
+          expect(service_offering).to receive(:order).and_call_original
+
+          expect(TopologicalInventory::AnsibleTower::Operations::Order::Request).to receive(:new).and_return(operation)
+          expect(operation).to receive(:run)
+
+          subject.process
+        end
+      end
+
+      context "applied_inventories task" do
+        let(:operation_name) { 'ServiceOffering.applied_inventories' }
+
+        it "runs applied inventories" do
+          expect(service_offering).to receive(:applied_inventories).and_call_original
+
+          expect(TopologicalInventory::AnsibleTower::Operations::AppliedInventories::Request).to receive(:new).and_return(operation)
+          expect(operation).to receive(:run)
+
+          subject.process
+        end
+      end
+    end
+
+    context "Source.availability_check task" do
+      let(:source_class) { TopologicalInventory::AnsibleTower::Operations::Source }
+      let(:operation_name) { 'Source.availability_check' }
+
+      it "runs availability check" do
+        source = source_class.new(params)
+        allow(source_class).to receive(:new).and_return(source)
+
+        expect(source).to receive(:availability_check)
+
+        subject.process
+      end
     end
   end
 end

--- a/spec/operations/worker_spec.rb
+++ b/spec/operations/worker_spec.rb
@@ -2,31 +2,80 @@ require "topological_inventory/ansible_tower/operations/worker"
 
 RSpec.describe TopologicalInventory::AnsibleTower::Operations::Worker do
   describe "#run" do
+    let(:async_worker) { double("Async worker") }
     let(:client) { double("ManageIQ::Messaging::Client") }
-    let(:subject) { described_class.new }
+    let(:message) { double("ManageIQ::Messaging::ReceivedMessage") }
+    let(:metrics) { double("Metrics", :record_operation => nil) }
+    let(:operation) { 'Test.operation' }
+    let(:task_id) { '1' }
+
+    subject { described_class.new(metrics) }
+
     before do
       require "manageiq-messaging"
       allow(TopologicalInventory::AnsibleTower::ConnectionManager).to receive_messages(:start_receptor_client => nil,
                                                                                        :stop_receptor_client  => nil)
-      allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
+      allow(subject).to receive(:async_worker).and_return(async_worker)
+      allow(async_worker).to receive_messages(:start => nil, :stop => nil)
+
+      allow(subject).to receive(:client).and_return(client)
       allow(client).to receive(:close)
+      allow(TopologicalInventory::Providers::Common::Operations::HealthCheck).to receive(:touch_file)
+      allow(message).to receive_messages(:ack => nil, :message => operation, :payload => {'params' => {'task_id' => task_id}})
+
       allow(subject).to receive(:logger).and_return(double('null_object').as_null_object)
       TopologicalInventory::AnsibleTower::MessagingClient.class_variable_set(:@@default, nil)
     end
 
-    it "calls subscribe_messages on the right queue" do
-      operations_topic = "platform.topological-inventory.operations-ansible-tower"
+    context "sync processing" do
+      it "calls subscribe_messages on the right queue" do
+        operations_topic = "platform.topological-inventory.operations-ansible-tower"
 
-      message = double("ManageIQ::Messaging::ReceivedMessage")
-      allow(message).to receive(:message)
-      allow(message).to receive(:payload)
-      allow(message).to receive(:ack)
+        expect(client).to receive(:subscribe_topic)
+          .with(hash_including(:service => operations_topic)).and_yield(message)
+        expect(TopologicalInventory::AnsibleTower::Operations::Processor)
+          .to receive(:process!).with(message, metrics)
 
-      expect(client).to receive(:subscribe_topic)
-        .with(hash_including(:service => operations_topic)).and_yield(message)
-      expect(TopologicalInventory::AnsibleTower::Operations::Processor)
-        .to receive(:process!).with(message)
-      subject.run
+        expect(async_worker).not_to receive(:enqueue)
+
+        subject.run
+      end
+    end
+
+    context "async processing" do
+      let(:operation) { "Source.availability_check" }
+
+      it "enqueues message in async worker" do
+        expect(async_worker).to receive(:enqueue).with(message)
+        expect(subject).not_to receive(:process_message)
+
+        operations_topic = "platform.topological-inventory.operations-ansible-tower"
+
+        expect(client).to(receive(:subscribe_topic)
+                            .with(hash_including(:service => operations_topic)).and_yield(message))
+
+        subject.run
+      end
+    end
+
+    context ".metrics" do
+      it "records successful operation" do
+        result = subject.operation_status[:success]
+
+        allow(TopologicalInventory::AnsibleTower::Operations::Processor).to receive(:process!).and_return(result)
+        expect(metrics).to receive(:record_operation).with(operation, :status => result)
+
+        subject.send(:process_message, message)
+      end
+
+      it "records exception" do
+        result = subject.operation_status[:error]
+
+        allow(TopologicalInventory::AnsibleTower::Operations::Processor).to receive(:process!).and_raise("Test Exception!")
+        expect(metrics).to receive(:record_operation).with(operation, :status => result)
+
+        subject.send(:process_message, message)
+      end
     end
   end
 end


### PR DESCRIPTION
**Issue** https://github.com/RedHatInsights/topological_inventory-api/issues/320
**Issue** https://github.com/RedHatInsights/topological_inventory-providers-common/issues/66

(similar PR like https://github.com/RedHatInsights/topological_inventory-amazon/pull/77)

Metrics for Availability_check:
* topological_inventory_ansible_tower_operations:
  * _status_counter (args: operation name and result) [counter]
  * _duration_seconds [histogram]

---

* [x] **depends on** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/57
* [x] **depends on** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/60 (+ release)
* [x] **depends on** https://github.com/RedHatInsights/topological_inventory-providers-common/pull/64 (+ release PR65)

---

[RHCLOUD-9949](https://issues.redhat.com/browse/RHCLOUD-9949)