### PR TITLE
Fix on-premise targeted refresh and account_number

### DIFF
--- a/lib/topological_inventory/ansible_tower/targeted_refresh/service_instance.rb
+++ b/lib/topological_inventory/ansible_tower/targeted_refresh/service_instance.rb
@@ -131,7 +131,7 @@ module TopologicalInventory
           @connection ||= begin
                             tower_user = authentication.username unless on_premise?
                             tower_passwd = authentication.password unless on_premise?
-                            account_number = account_number_by_identity(identity) unless on_premise?
+                            account_number = account_number_by_identity(identity)
 
                             connection_manager.connect(
                               :base_url       => full_hostname(endpoint),


### PR DESCRIPTION
It seems like account number is not provided to ordering through receptor. Probably caused by #131 

Similar to #143 

---

[SSP-1948](https://issues.redhat.com/browse/SSP-1948)