### PR TITLE
Update travis URL in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # topological_inventory-ansible_tower
 
-[![Build Status](https://travis-ci.org/RedHatInsights/topological_inventory-ansible_tower.svg?branch=master)](https://travis-ci.org/RedHatInsights/topological_inventory-ansible_tower)
+[![Build Status](https://travis-ci.com/RedHatInsights/topological_inventory-ansible_tower.svg?branch=master)](https://travis-ci.com/RedHatInsights/topological_inventory-ansible_tower)
 [![Maintainability](https://api.codeclimate.com/v1/badges/186cd37b6c71344ac6ce/maintainability)](https://codeclimate.com/github/RedHatInsights/topological_inventory-ansible_tower/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/186cd37b6c71344ac6ce/test_coverage)](https://codeclimate.com/github/RedHatInsights/topological_inventory-ansible_tower/test_coverage)
 [![Security](https://hakiri.io/github/ManageIQ/topological_inventory-ansible_tower/master.svg)](https://hakiri.io/github/ManageIQ/topological_inventory-ansible_tower/master)


### PR DESCRIPTION
Travis migrated from URL travis-ci.org -> travis-ci.com.

This PR is based on https://github.com/RedHatInsights/topological_inventory-api/issues/334 issue.