### PR TITLE
Removed log_with from targeted_refresh

### DIFF
--- a/lib/topological_inventory/ansible_tower/targeted_refresh/worker.rb
+++ b/lib/topological_inventory/ansible_tower/targeted_refresh/worker.rb
@@ -39,10 +39,8 @@ module TopologicalInventory
           model, method = message.message.to_s.split(".")
           payload = JSON.parse(message.payload) if message.payload.present?
 
-          log_with(request_ids(payload)) do
-            logger.info("Received message #{model}##{method}, #{payload}")
-            TargetedRefresh::Processor.process!(message, payload)
-          end
+          logger.info("Received message #{model}##{method}, #{payload}")
+          TargetedRefresh::Processor.process!(message, payload)
         rescue JSON::ParserError
           logger.error("#{model}##{method} - Failed to parse payload: #{message.payload}")
           raise
@@ -51,15 +49,10 @@ module TopologicalInventory
                        ids = payload['params'].to_a.collect { |task| task['task_id'] }
                        ids.compact!
                      end
-          logger.error("#{model}##{method} - Task[ id: #{tasks_id.to_a.join(' | id: ')} ] #{err.cause}\n#{err}\n#{err.backtrace.join("\n")}")
+          logger.error("#{model}##{method} - Task[ id: #{tasks_id.to_a.join(' | id: ')} ] #{err.message}\n#{err}\n#{err.backtrace.join("\n")}")
           raise
         ensure
           message.ack
-        end
-
-        def request_ids(payload)
-          ids = payload['params'].to_a.collect { |param| param['request_context'] }
-          ids.join(' ')
         end
       end
     end


### PR DESCRIPTION
Prod issue: There are many running tasks (in our db) and scheduler is paginating it by 1000 tasks (it means 1000x Task.x_rh_forwardable). It's then logged by log_with (link), which saves this long string into Thread.current. So the problem is, that we can't log as much x-rh- headers for easier kibana tracking and can't save it to Thread.current (also in all operation workers).

In the initial log, it tries to log all x-rh-headers 2x (once as "params", once as the "request_id")

---

https://issues.redhat.com/browse/RHCLOUD-10859