### PR TITLE
Add `group.instance.id` settings to targeted refresh listener

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 Dockerfile
 Gemfile.lock
 .git
+vendor/*
+.bundle/*


### PR DESCRIPTION
So after asking Chris Mitchell to look at our targeted collector topic on Kafka we found out consumers are getting kicked out and rebalances are occurring. That's why the listeners just stop and then start again after the rebalance is done. 

I spoke with Chris and Bill about a potential solution, and that is setting up the [group instance id](https://kafka.apache.org/documentation/#group.instance.id). Which tells Kafka that we're a consistent group of consumers, and that if we go away for a bit we'll definitely be back shortly. So do not do a rebalance (which can take minutes). It may solve our problem, as seen here:
```
[2020-12-01 20:21:37,445] INFO [GroupCoordinator 0]: Static member Some(mewtwo) with unknown member id rejoins, assigning new member id mewtwo-1606853869276, while old member mewtwo-1606853869276 will be removed. (kafka.coordinator.group.GroupCoordinator)
[2020-12-01 20:21:37,445] INFO [GroupCoordinator 0]: Static member joins during Stable stage will not trigger rebalance. (kafka.coordinator.group.GroupCoordinator)
```
This is what happens when I kill my local listener and reconnect. So the basic flow is we increase our time-out to 120 seconds so it won't rebalance until a consumer has been gone for 2 minutes, which should only happen when there is a redeployment. 

I think this is worth trying - because we're seeing consistent rebalances again like we were before where the listener isn't heart-beating right etc which is unfortunate, but this would fix that I hope. 