### PR TITLE
Targeted refresh: Kafka rebalance handling and messages skipping

### DIFF
--- a/lib/topological_inventory/ansible_tower/messaging_client.rb
+++ b/lib/topological_inventory/ansible_tower/messaging_client.rb
@@ -11,14 +11,13 @@ module TopologicalInventory
         @worker_listener ||= ManageIQ::Messaging::Client.open(worker_listener_opts)
       end
 
-      def targeted_refresh_listener
-        @targeted_refresh_listener ||= ManageIQ::Messaging::Client.open(targeted_refresh_listener_opts).tap do |client|
-          # persistent workers by pod hostname, this will prevent rebalances.
-          client.send(:kafka_client)[:"group.instance.id"] = ENV['HOSTNAME']
-
-          # 30 second timeout, after this the worker of the old hostname (ie in the event of a redeploy) will be removed and the topic will be rebalanced.
-          client.send(:kafka_client)[:"session.timeout.ms"] = 30 * 1000
+      def targeted_refresh_listener(renew: false)
+        if renew
+          @targeted_refresh_listener&.close
+          @targeted_refresh_listener = nil
         end
+
+        @targeted_refresh_listener ||= ManageIQ::Messaging::Client.open(targeted_refresh_listener_opts)
       end
 
       def worker_listener_queue_opts

--- a/spec/targeted_refresh/worker_spec.rb
+++ b/spec/targeted_refresh/worker_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe TopologicalInventory::AnsibleTower::TargetedRefresh::Worker do
   before do
     allow(subject).to receive(:client).and_return(client)
     allow(client).to receive(:close)
+    TopologicalInventory::AnsibleTower::MessagingClient.class_variable_set(:@@default, nil)
   end
 
   describe "#run" do


### PR DESCRIPTION
1) Closes and creates new kafka client when Rdkafka::RdkafkaError occurs (in our case `Rdkafka::RdkafkaError\nLocal: Maximum application poll interval (max.poll.interval.ms) exceeded (max_poll_exceeded)`)

2) Skips messages without or with old "sent_at" timestamp, there is no risk of lost data. 


- [ ] **depends on** https://github.com/RedHatInsights/topological_inventory-scheduler/pull/11
---

https://issues.redhat.com/browse/RHCLOUD-10859