### PR TITLE
Partial refresh fix

### DIFF
--- a/lib/topological_inventory/ansible_tower/collector/scheduler.rb
+++ b/lib/topological_inventory/ansible_tower/collector/scheduler.rb
@@ -26,7 +26,7 @@ module TopologicalInventory
         end
 
         def add_source(source_uid)
-          timestamps[source_uid] = {:full_refresh => {}, :partial_refresh => {}}
+          timestamps.put_if_absent(source_uid, {:full_refresh => {}, :partial_refresh => {}})
         end
 
         def remove_source(source_uid)


### PR DESCRIPTION
Collectors_pool was reseting scheduler timestamps so every refresh was considered as full_refresh

---

[RHCLOUD-11165](https://issues.redhat.com/browse/RHCLOUD-11165)