### PR TITLE
Fix on-premise Targeted refresh

### DIFF
--- a/lib/topological_inventory/ansible_tower/targeted_refresh/service_instance.rb
+++ b/lib/topological_inventory/ansible_tower/targeted_refresh/service_instance.rb
@@ -61,7 +61,7 @@ module TopologicalInventory
           logger.error_ext(operation, "Error: #{err.message}\n#{err.backtrace.join("\n")}")
         end
 
-        def async_save_inventory(refresh_state_uuid, parser)
+        def async_save_inventory(_entity_type, refresh_state_uuid, parser)
           refresh_state_part_collected_at = Time.now.utc
           refresh_state_part_uuid = SecureRandom.uuid
           save_inventory(parser.collections.values, inventory_name, schema_name, refresh_state_uuid, refresh_state_part_uuid, refresh_state_part_collected_at)


### PR DESCRIPTION
The `async_save_inventory` method was extended by `entity_type` argument recently and not updated here. 
It caused archiving jobs for on-premise Sources

---

[RHCLOUD-11677](https://issues.redhat.com/browse/RHCLOUD-11677)